### PR TITLE
Enable code generation in the absence of register reset values.

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -759,19 +759,6 @@ pub fn register(
     }
 
     if access == Access::WriteOnly || access == Access::ReadWrite {
-        reg_impl_items.push(quote! {
-            /// Writes to the register
-            #[inline]
-            pub fn write<F>(&self, f: F)
-            where
-                F: FnOnce(&mut W) -> &mut W
-            {
-                let mut w = W::reset_value();
-                f(&mut w);
-                self.register.set(w.bits);
-            }
-        });
-
         mod_items.push(quote! {
             /// Value to write to the register
             pub struct W {
@@ -782,16 +769,42 @@ pub fn register(
         let rv = register
             .reset_value
             .or(defs.reset_value)
-            .map(|rv| util::hex(rv))
-            .ok_or_else(|| format!("Register {} has no reset value", register.name))?;
+            .map(|rv| util::hex(rv));
+
+        if let Some(rv) = rv {
+            reg_impl_items.push(quote! {
+                /// Writes to the register
+                #[inline]
+                pub fn write<F>(&self, f: F)
+                where
+                    F: FnOnce(&mut W) -> &mut W
+                {
+                    let mut w = W::reset_value();
+                    f(&mut w);
+                    self.register.set(w.bits);
+                }
+            });
+
+            w_impl_items.push(quote! {
+                /// Reset value of the register
+                #[inline]
+                pub fn reset_value() -> W {
+                    W { bits: #rv }
+                }
+            });
+
+            if access == Access::ReadWrite {
+                reg_impl_items.push(quote! {
+                    /// Writes the reset value to the register
+                    #[inline]
+                    pub fn reset(&self) {
+                        self.write(|w| w)
+                    }
+                });
+            }
+        }
 
         w_impl_items.push(quote! {
-            /// Reset value of the register
-            #[inline]
-            pub fn reset_value() -> W {
-                W { bits: #rv }
-            }
-
             /// Writes raw bits to the register
             #[inline]
             pub #unsafety fn bits(&mut self, bits: #rty) -> &mut Self {
@@ -799,16 +812,6 @@ pub fn register(
                 self
             }
         });
-    }
-
-    if access == Access::ReadWrite {
-        reg_impl_items.push(quote! {
-            /// Writes the reset value to the register
-            #[inline]
-            pub fn reset(&self) {
-                self.write(|w| w)
-            }
-        })
     }
 
     mod_items.push(quote! {


### PR DESCRIPTION
The second commit also generates `reset` for write-only registers. Previously it was only generated for read-write registers. I'm not sure if the previous behavior was intended. This resolves #174.