### PR TITLE
Do not transform peripheral names

### DIFF
--- a/src/generate.rs
+++ b/src/generate.rs
@@ -8,7 +8,7 @@ use svd::{Access, BitRange, Defaults, Device, EnumeratedValues, Field, Periphera
 use syn::{self, Ident};
 
 use errors::*;
-use util::{self, ToSanitizedSnakeCase, ToSanitizedUpperCase, U32Ext, BITS_PER_BYTE};
+use util::{self, Sanitize, ToSanitizedSnakeCase, ToSanitizedUpperCase, U32Ext, BITS_PER_BYTE};
 use Target;
 
 /// Whole device generation
@@ -141,7 +141,7 @@ pub fn device(d: &Device, target: &Target, items: &mut Vec<Tokens>) -> Result<()
             continue;
         }
 
-        let p = p.name.to_sanitized_upper_case();
+        let p = p.name.sanitize();
         let id = Ident::new(&*p);
         fields.push(quote! {
             #[doc = #p]
@@ -457,7 +457,7 @@ pub fn peripheral(
     items: &mut Vec<Tokens>,
     defaults: &Defaults,
 ) -> Result<()> {
-    let name_pc = Ident::new(&*p.name.to_sanitized_upper_case());
+    let name = Ident::new(&*p.name.sanitize());
     let address = util::hex(p.base_address);
     let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
 
@@ -473,22 +473,22 @@ pub fn peripheral(
 
     items.push(quote! {
         #[doc = #description]
-        pub struct #name_pc { _marker: PhantomData<*const ()> }
+        pub struct #name { _marker: PhantomData<*const ()> }
 
-        unsafe impl Send for #name_pc {}
+        unsafe impl Send for #name {}
 
-        impl #name_pc {
+        impl #name {
             /// Returns a pointer to the register block
             pub fn ptr() -> *const #base::RegisterBlock {
                 #address as *const _
             }
         }
 
-        impl Deref for #name_pc {
+        impl Deref for #name {
             type Target = #base::RegisterBlock;
 
             fn deref(&self) -> &#base::RegisterBlock {
-                unsafe { &*#name_pc::ptr() }
+                unsafe { &*#name::ptr() }
             }
         }
     });

--- a/src/generate.rs
+++ b/src/generate.rs
@@ -143,11 +143,12 @@ pub fn device(d: &Device, target: &Target, items: &mut Vec<Tokens>) -> Result<()
 
         let p = p.name.sanitize();
         let id = Ident::new(&*p);
+        let id_sc = Ident::new(&*p.to_sanitized_snake_case());
         fields.push(quote! {
             #[doc = #p]
-            pub #id: #id
+            pub #id_sc: #id
         });
-        exprs.push(quote!(#id: #id { _marker: PhantomData }));
+        exprs.push(quote!(#id_sc: #id { _marker: PhantomData }));
     }
 
     let take = match *target {

--- a/src/util.rs
+++ b/src/util.rs
@@ -13,6 +13,10 @@ pub const BITS_PER_BYTE: u32 = 8;
 /// that are not valid in Rust ident
 const BLACKLIST_CHARS: &'static [char] = &['(', ')', '[', ']'];
 
+pub trait Sanitize {
+    fn sanitize(&self) -> Cow<str>;
+}
+
 pub trait ToSanitizedPascalCase {
     fn to_sanitized_pascal_case(&self) -> Cow<str>;
 }
@@ -23,6 +27,12 @@ pub trait ToSanitizedUpperCase {
 
 pub trait ToSanitizedSnakeCase {
     fn to_sanitized_snake_case(&self) -> Cow<str>;
+}
+
+impl Sanitize for str {
+    fn sanitize(&self) -> Cow<str> {
+        Cow::from(self.replace(BLACKLIST_CHARS, ""))
+    }
 }
 
 impl ToSanitizedSnakeCase for str {


### PR DESCRIPTION
Currently, `svd2rust` always transforms peripheral names to uppercase. For peripherals that are not acronyms, like SysTick, the resulting type name looks a little odd. This patch simply sanitizes peripheral names, but leaves them in their original case. For vendor SVDs with weirdly-formatted names, an XML transform or .patch could be used to fix them, much like device-specific crates already do to add `enumeratedValues` and such.

This is a breaking change that could lead to API breakage in existing crates that assume the uppercase transformation is always done.