### PR TITLE
handle register derivedFrom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,5 @@ either = "1.0.3"
 error-chain = "0.11.0"
 inflections = "1.1.0"
 quote = "0.3.15"
-svd-parser = "0.6"
+svd-parser = { git = "https://github.com/japaric/svd" }
 syn = "0.11.11"

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -39,9 +39,9 @@ pub fn render(
 
     let name_sc = Ident::new(&*p.name.to_sanitized_snake_case());
     let base = if derive_regs {
-        Ident::new(&*p_derivedfrom.unwrap().name.to_sanitized_snake_case());
+        Ident::new(&*p_derivedfrom.unwrap().name.to_sanitized_snake_case())
     } else {
-        name_sc.clone();
+        name_sc.clone()
     };
 
     // Insert the peripheral structure


### PR DESCRIPTION
Building on https://github.com/japaric/svd2rust/pull/190 (the bottom two commits are basically that PR), this PR adds support for generating code for registers that have the derivedFrom attribute set on them.

This is needed to resolve the `WARNING: field Some(Ident("pmux1_1")) has different offset 177 than its union container 176` mentioned in https://github.com/japaric/svd2rust/pull/192


