### PR TITLE
Provide library access to code generation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,10 +439,12 @@ mod generate;
 mod util;
 
 pub use util::Target;
+use util::build_rs;
 
 pub struct Generation {
     pub lib_rs: String,
     pub device_x: String,
+    pub build_rs: String,
 }
 
 type Result<T> = std::result::Result<T, SvdError>;
@@ -472,6 +474,7 @@ pub fn generate(xml: &str, target: &Target, nightly: bool) -> Result<Generation>
     Ok(Generation {
         lib_rs: lib_rs,
         device_x: device_x,
+        build_rs: build_rs().to_string(),
     })
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,12 +439,21 @@ mod generate;
 mod util;
 
 pub use util::Target;
-use util::build_rs;
 
 pub struct Generation {
     pub lib_rs: String,
+    pub device_specific: Option<DeviceSpecific>,
+
+    // Reserve the right to add more fields to this struct
+    _extensible: (),
+}
+
+pub struct DeviceSpecific {
     pub device_x: String,
     pub build_rs: String,
+
+    // Reserve the right to add more fields to this struct
+    _extensible: (),
 }
 
 type Result<T> = std::result::Result<T, SvdError>;
@@ -470,11 +479,23 @@ pub fn generate(xml: &str, target: &Target, nightly: bool) -> Result<Generation>
         quote! {
             #(#items)*
         }
-    ).or(Err(SvdError::Fmt))?;
+    )
+    .or(Err(SvdError::Fmt))?;
+
+    let device_specific = if device_x.is_empty() {
+        None
+    } else {
+        Some(DeviceSpecific {
+            device_x: device_x,
+            build_rs: util::build_rs().to_string(),
+            _extensible: (),
+        })
+    };
+
     Ok(Generation {
         lib_rs: lib_rs,
-        device_x: device_x,
-        build_rs: build_rs().to_string(),
+        device_specific: device_specific,
+        _extensible: (),
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,11 +19,10 @@ use std::fs::File;
 use std::process;
 use std::io::{self, Write};
 
-use quote::Tokens;
 use clap::{App, Arg};
 
 use errors::*;
-use util::Target;
+use util::{build_rs, Target};
 
 fn run() -> Result<()> {
     use std::io::Read;
@@ -114,30 +113,5 @@ fn main() {
         }
 
         process::exit(1);
-    }
-}
-
-fn build_rs() -> Tokens {
-    quote! {
-        use std::env;
-        use std::fs::File;
-        use std::io::Write;
-        use std::path::PathBuf;
-
-        fn main() {
-            if env::var_os("CARGO_FEATURE_RT").is_some() {
-                // Put the linker script somewhere the linker can find it
-                let out = &PathBuf::from(env::var_os("OUT_DIR").unwrap());
-                File::create(out.join("device.x"))
-                    .unwrap()
-                    .write_all(include_bytes!("device.x"))
-                    .unwrap();
-                println!("cargo:rustc-link-search={}", out.display());
-
-                println!("cargo:rerun-if-changed=device.x");
-            }
-
-            println!("cargo:rerun-if-changed=build.rs");
-        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,26 +23,7 @@ use quote::Tokens;
 use clap::{App, Arg};
 
 use errors::*;
-
-#[derive(Clone, Copy, PartialEq)]
-pub enum Target {
-    CortexM,
-    Msp430,
-    RISCV,
-    None,
-}
-
-impl Target {
-    fn parse(s: &str) -> Result<Self> {
-        Ok(match s {
-            "cortex-m" => Target::CortexM,
-            "msp430" => Target::Msp430,
-            "riscv" => Target::RISCV,
-            "none" => Target::None,
-            _ => bail!("unknown target {}", s),
-        })
-    }
-}
+use util::Target;
 
 fn run() -> Result<()> {
     use std::io::Read;

--- a/src/util.rs
+++ b/src/util.rs
@@ -14,6 +14,26 @@ pub const BITS_PER_BYTE: u32 = 8;
 /// that are not valid in Rust ident
 const BLACKLIST_CHARS : &[char] = &['(', ')', '[', ']', '/', ' '];
 
+#[derive(Clone, Copy, PartialEq)]
+pub enum Target {
+    CortexM,
+    Msp430,
+    RISCV,
+    None,
+}
+
+impl Target {
+    pub fn parse(s: &str) -> Result<Self> {
+        Ok(match s {
+            "cortex-m" => Target::CortexM,
+            "msp430" => Target::Msp430,
+            "riscv" => Target::RISCV,
+            "none" => Target::None,
+            _ => bail!("unknown target {}", s),
+        })
+    }
+}
+
 pub trait ToSanitizedPascalCase {
     fn to_sanitized_pascal_case(&self) -> Cow<str>;
 }


### PR DESCRIPTION
This change implements the minimal API described in #207 to allow downstream build.rs scripts to generate the svd2rust output.