### PR TITLE
Derive common traits for write enums like for read enums

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -685,6 +685,7 @@ pub fn fields(
                     let variants_doc = variants.iter().map(|v| &*v.doc);
                     mod_items.push(quote! {
                         #[doc = #pc_w_doc]
+                        #[derive(Clone, Copy, Debug, PartialEq)]
                         pub enum #pc_w {
                             #(#[doc = #variants_doc]
                             #variants_pc),*


### PR DESCRIPTION
The enums are just values so this should do no harm, and it helps
building interfaces around the peripherals that do validation or
otherwise pass those values around.

Closes: https://github.com/japaric/svd2rust/issues/135