### PR TITLE
Remove #[deny(warnings)] from generated code

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,18 +1,18 @@
 build:stable:
   image: rust:stretch
   script:
-    - cargo build
+    - RUSTFLAGS="-D warnings" cargo build
 
 build:nightly:
   image: rustlang/rust:nightly
   script:
-    - cargo build
+    - RUSTFLAGS="-D warnings" cargo build
 
 regress:nightly:
   image: rustlang/rust:nightly
   script:
-    - cargo build --release
+    - RUSTFLAGS="-D warnings" cargo build --release
     - rustup component add rustfmt-preview
     - cd ci/svd2rust-regress
     - rm -rf ./output
-    - cargo run --release -- --long-test --format --verbose
+    - RUSTFLAGS="-D warnings" cargo run --release -- --long-test --format --verbose

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
   global:
     - CRATE_NAME=svd2rust
     - TARGET=x86_64-unknown-linux-gnu
+    - RUSTFLAGS="-D warnings"
 
 matrix:
   include:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,11 +31,11 @@ install:
 
 test_script:
   - if [%APPVEYOR_REPO_TAG%]==[false] (
-      cargo build --target %TARGET%
+      RUSTFLAGS="-D warnings" cargo build --target %TARGET%
     )
 
 before_deploy:
-  - cargo rustc --target %TARGET% --release --bin svd2rust -- -C lto
+  - cargo rustc --target %TARGET% --release --bin svd2rust -- -C lto -D warnings
   - ps: ci\before_deploy.ps1
 
 deploy:

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -9,7 +9,12 @@ use Target;
 use generate::{interrupt, peripheral};
 
 /// Whole device generation
-pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String) -> Result<Vec<Tokens>> {
+pub fn render(
+    d: &Device,
+    target: &Target,
+    nightly: bool,
+    device_x: &mut String,
+) -> Result<Vec<Tokens>> {
     let mut out = vec![];
 
     let doc = format!(
@@ -38,7 +43,6 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
     out.push(quote! {
         #![doc = #doc]
         #![deny(missing_docs)]
-        #![deny(warnings)]
         #![allow(non_camel_case_types)]
         #![no_std]
     });
@@ -103,7 +107,7 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
     out.extend(interrupt::render(target, &d.peripherals, device_x)?);
 
     const CORE_PERIPHERALS: &[&str] = &[
-        "CBP", "CPUID", "DCB", "DWT", "FPB", "FPU", "ITM", "MPU", "NVIC", "SCB", "SYST", "TPIU"
+        "CBP", "CPUID", "DCB", "DWT", "FPB", "FPU", "ITM", "MPU", "NVIC", "SCB", "SYST", "TPIU",
     ];
 
     let mut fields = vec![];


### PR DESCRIPTION
This declaration causes errors when using cargo doc, since some doc comments include lines that give doc warnings. This doesn't prevent the crate from building, so it's easy for these doc comment warnings to slip through to releases. However, because of this line (which can't be disabled later on), doc comment warnings are treated as errors and prevent documentation for the generated crate from building, as well as any other crate that depends on the generated crate.

For example, the `nrf51` crate is generated with `svd2rust`. This line causes the docs in that crate to error when building. The `nrf51-hal` crate depends on `nrf51`, and so it's docs don't build either. The `microbit` crate depends on `nrf51-hal`, so it's docs don't build either. Finally, any other crate that depends on any of those can't build docs. This makes it extraordinarily difficult to program using any of these crates.

For more detailed information about the above case, check out therealprof/nrf51#3.