### PR TITLE
Add escape sequences for special characters in docstrings

### DIFF
--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -43,15 +43,14 @@ pub fn render(
         pos += 1;
 
         let name_uc = Ident::new(interrupt.name.to_sanitized_upper_case());
-        let description = format!(
+        let description = util::normalize_docstring(format!(
             "{} - {}",
             interrupt.value,
             interrupt
                 .description
                 .as_ref()
-                .map(|s| util::respace(s))
-                .unwrap_or_else(|| interrupt.name.clone())
-        );
+                .unwrap_or(&interrupt.name)
+        ));
 
         let value = util::unsuffixed(u64(interrupt.value));
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -21,7 +21,12 @@ pub fn render(
 
     let name_pc = Ident::new(&*p.name.to_sanitized_upper_case());
     let address = util::hex(p.base_address);
-    let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
+    let description = util::normalize_docstring(format!(
+        "{}",
+        p.description
+         .as_ref()
+         .unwrap_or(&p.name)
+    ));
 
     let name_sc = Ident::new(&*p.name.to_sanitized_snake_case());
     let (base, derived) = if let Some(base) = p.derived_from.as_ref() {
@@ -95,7 +100,12 @@ pub fn render(
         )?);
     }
 
-    let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
+    let description = util::normalize_docstring(format!(
+        "{}",
+        p.description
+         .as_ref()
+         .unwrap_or(&p.name)
+    ));
     out.push(quote! {
         #[doc = #description]
         pub mod #name_sc {
@@ -499,7 +509,7 @@ fn register_or_cluster_block_nightly(
                 }
             };
 
-            let description = region.description();
+            let description = util::normalize_docstring(region.description());
 
             helper_types.append(quote! {
                 #[doc = #description]
@@ -718,7 +728,10 @@ fn cluster_block(
     let mut mod_items: Vec<Tokens> = vec![];
 
     // name_sc needs to take into account array type.
-    let description = util::respace(&c.description);
+    let description = util::normalize_docstring(format!(
+        "{}",
+        &c.description
+    ));
 
     // Generate the register block.
     let mod_name = match *c {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -31,7 +31,10 @@ pub fn render(
         rsize.next_power_of_two()
     };
     let rty = rsize.to_ty()?;
-    let description = util::respace(&register.description);
+    let description = util::normalize_docstring(format!(
+        "{}",
+        &register.description
+    ));
 
     let unsafety = unsafety(register.write_constraint.as_ref(), rsize);
 
@@ -374,7 +377,10 @@ pub fn fields(
                     }
                 }
 
-                let description = &f.description;
+                let description = util::normalize_docstring(format!(
+                     "{}",
+                     &f.description
+                ));
                 let sc = &f.sc;
                 r_impl_items.push(quote! {
                     #[doc = #description]
@@ -390,7 +396,7 @@ pub fn fields(
                     let mut vars = variants
                         .iter()
                         .map(|v| {
-                            let desc = v.description;
+                            let desc = util::normalize_docstring(format!("{}", &v.description));
                             let pc = &v.pc;
                             quote! {
                                 #[doc = #desc]
@@ -601,7 +607,7 @@ pub fn fields(
                 }
 
                 let pc_w = &f.pc_w;
-                let pc_w_doc = format!("Values that can be written to the field `{}`", f.name);
+                let pc_w_doc = util::normalize_docstring(format!("Values that can be written to the field `{}`", f.name));
 
                 let base_pc_w = base.as_ref().map(|base| {
                     let pc = base.field.to_sanitized_upper_case();
@@ -728,7 +734,7 @@ pub fn fields(
                     let pc = &v.pc;
                     let sc = &v.sc;
 
-                    let doc = util::respace(&v.doc);
+                    let doc = util::normalize_docstring(format!("{}", &v.doc));
                     if let Some(enum_) = base_pc_w.as_ref() {
                         proxy_items.push(quote! {
                             #[doc = #doc]
@@ -788,7 +794,7 @@ pub fn fields(
                 }
             });
 
-            let description = &f.description;
+            let description = util::normalize_docstring(format!("{}", &f.description));
             let sc = &f.sc;
             w_impl_items.push(quote! {
                 #[doc = #description]

--- a/src/util.rs
+++ b/src/util.rs
@@ -261,3 +261,36 @@ pub fn only_registers(ercs: &[Either<Register, Cluster>]) -> Vec<&Register> {
         .collect();
     registers
 }
+
+/// Return a String which can be used as text in the #[doc] attribute
+pub fn normalize_docstring<S: Into<String>>(doc_string: S) -> String {
+    respace(&doc_string.into())
+        .replace("[", "\\[")
+        .replace("]", "\\]")
+}
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn normalize_docstring_ensures_correct_spacing()
+    {
+        let expected = "Some docstring - Line\\[0:10\\]";
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", " ", " ")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "  ", "   ")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "\n", "\n\n")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "\r", "\r\r")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "\t", "\t\t")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "\r\n\t", "\n\t\r")));
+        assert_eq!(expected, normalize_docstring(format!("Some docstring{}-{}Line[0:10]", "\r\n", "\n\r")));
+    }
+
+    #[test]
+    fn normalize_dcostring_escapes_brackets_in_docstring()
+    {
+        let expected = "Some docstring - Line\\[0:10\\]";
+        assert_eq!("Some docstring - Line\\[0:10\\]", normalize_docstring("Some docstring - Line[0:10]"));
+    }
+}


### PR DESCRIPTION
Cargo will fail to generate documentation if `[` and `[` are not
escaped in docstrings. Therefore an additional transformation
for escape sequences is done before the docstring is written to file.