### PR TITLE
re-export the `interrupt` attribute

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -126,7 +126,7 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
             pub use cortex_m::peripheral::Peripherals as CorePeripherals;
             #[cfg(feature = "rt")]
             pub use cortex_m_rt::interrupt;
-            pub use Interrupt as interrupt;
+            pub use self::Interrupt as interrupt;
         });
 
         if fpu_present {

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -124,6 +124,9 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
     if *target == Target::CortexM {
         out.push(quote! {
             pub use cortex_m::peripheral::Peripherals as CorePeripherals;
+            #[cfg(feature = "rt")]
+            pub use cortex_m_rt::interrupt;
+            pub use Interrupt as interrupt;
         });
 
         if fpu_present {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -264,7 +264,7 @@ pub fn render(
             });
 
             root.push(quote! {
-                pub use interrupt::Interrupt;
+                pub use self::interrupt::Interrupt;
             });
         }
     }

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -100,64 +100,6 @@ pub fn render(
                 pub static __INTERRUPTS: [Vector; #n] = [
                     #(#elements,)*
                 ];
-
-                /// Macro to override a device specific interrupt handler
-                ///
-                /// # Syntax
-                ///
-                /// ``` ignore
-                /// interrupt!(
-                ///     // Name of the interrupt
-                ///     $Name:ident,
-                ///
-                ///     // Path to the interrupt handler (a function)
-                ///     $handler:path,
-                ///
-                ///     // Optional, state preserved across invocations of the handler
-                ///     state: $State:ty = $initial_state:expr,
-                /// );
-                /// ```
-                ///
-                /// Where `$Name` must match the name of one of the variants of the `Interrupt`
-                /// enum.
-                ///
-                /// The handler must have signature `fn()` is no state was associated to it;
-                /// otherwise its signature must be `fn(&mut $State)`.
-                #[cfg(feature = "rt")]
-                #[macro_export]
-                macro_rules! interrupt {
-                    ($Name:ident, $handler:path,state: $State:ty = $initial_state:expr) => {
-                        #[allow(unsafe_code)]
-                        #[deny(private_no_mangle_fns)] // raise an error if this item is not accessible
-                        #[no_mangle]
-                        pub unsafe extern "C" fn $Name() {
-                            static mut STATE: $State = $initial_state;
-
-                            // check that this interrupt exists
-                            let _ = $crate::Interrupt::$Name;
-
-                            // validate the signature of the user provided handler
-                            let f: fn(&mut $State) = $handler;
-
-                            f(&mut STATE)
-                        }
-                    };
-
-                    ($Name:ident, $handler:path) => {
-                        #[allow(unsafe_code)]
-                        #[deny(private_no_mangle_fns)] // raise an error if this item is not accessible
-                        #[no_mangle]
-                        pub unsafe extern "C" fn $Name() {
-                            // check that this interrupt exists
-                            let _ = $crate::Interrupt::$Name;
-
-                            // validate the signature of the user provided handler
-                            let f: fn() = $handler;
-
-                            f()
-                        }
-                    };
-                }
             });
         }
         Target::Msp430 => {
@@ -313,16 +255,16 @@ pub fn render(
     }
 
     if !interrupts.is_empty() {
-        root.push(quote! {
-            #[doc(hidden)]
-            pub mod interrupt {
-                #(#mod_items)*
-            }
-        });
-
         if *target != Target::CortexM {
             root.push(quote! {
-                pub use self::interrupt::Interrupt;
+                #[doc(hidden)]
+                pub mod interrupt {
+                    #(#mod_items)*
+                }
+            });
+
+            root.push(quote! {
+                pub use interrupt::Interrupt;
             });
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,14 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` v0.5.x and `vcell` v0.1.x. Furthermore the
+//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` v0.6.x and `vcell` v0.1.x. Furthermore the
 //! "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
 //! bare-metal = "0.2.0"
-//! cortex-m = "0.5.0"
+//! cortex-m = "0.6.4"
 //! vcell = "0.1.0"
 //!
 //! [dependencies.cortex-m-rt]
@@ -420,7 +420,10 @@
 //!
 //! If the "rt" Cargo feature of the svd2rust generated crate is enabled the crate will populate the
 //! part of the vector table that contains the interrupt vectors and provide an
-//! [`interrupt!`](macro.interrupt.html) macro that can be used to register interrupt handlers.
+//! [`interrupt!`](macro.interrupt.html) macro (non Cortex-M targets) or [`interrupt`] attribute
+//! (Cortex-M) that can be used to register interrupt handlers.
+//!
+//! [`interrupt`]: TODO(add link here)
 //!
 //! ## the `--nightly` flag
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -423,7 +423,7 @@
 //! [`interrupt!`](macro.interrupt.html) macro (non Cortex-M targets) or [`interrupt`] attribute
 //! (Cortex-M) that can be used to register interrupt handlers.
 //!
-//! [`interrupt`]: TODO(add link here)
+//! [`interrupt`]: https://docs.rs/cortex-m-rt-macros/0.1/cortex_m_rt_macros/attr.interrupt.html
 //!
 //! ## the `--nightly` flag
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,8 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` v0.6.x and `vcell` v0.1.x. Furthermore the
-//! "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
+//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` >=v0.6.5 and `vcell` v0.1.x. Furthermore
+//! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
@@ -65,7 +65,7 @@
 //!
 //! [dependencies.cortex-m-rt]
 //! optional = true
-//! version = "0.5.0"
+//! version = "0.6.5"
 //!
 //! [features]
 //! rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
this is a breaking change because

- it bumps the cortex-m-rt version requirement to v0.6.4

- it changes the behavior of the `<device>::interrupt` item. This item was a
bang macro and now has become an attribute.