### PR TITLE
Remove debug assert from Peripherals::steal

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -188,8 +188,6 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
 
             /// Unchecked version of `Peripherals::take`
             pub unsafe fn steal() -> Self {
-                debug_assert!(!DEVICE_PERIPHERALS);
-
                 DEVICE_PERIPHERALS = true;
 
                 Peripherals {


### PR DESCRIPTION
Very simple PR! :)

This permits actually-unsafe use of the steal method, and avoids divergent behavior between debug and release modes.