### PR TITLE
Make generated interrupt enum more useful

### DIFF
--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -257,7 +257,7 @@ pub fn render(
         });
 
         root.push(quote! {
-            pub use self::interrupt::Interrupt;
+            pub use self::interrupt::{Interrupt, Nr, TryFromInterruptError};
         });
     }
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -169,27 +169,25 @@ pub fn render(
                 }
             }
         }
+
+        #[derive(Debug, Copy, Clone)]
+        pub struct TryFromInterruptError(());
+
+        impl Interrupt {
+            #[inline]
+            pub fn try_from(value: u8) -> Result<Self, TryFromInterruptError> {
+                match value {
+                    #(#from_arms)*
+                    _ => Err(TryFromInterruptError(())),
+                }
+            }
+        }
     };
 
     if target == Target::CortexM {
         root.push(interrupt_enum);
     } else {
-        mod_items.push(quote! {
-            #interrupt_enum
-
-            #[derive(Debug, Copy, Clone)]
-            pub struct TryFromInterruptError(());
-
-            impl Interrupt {
-                #[inline]
-                pub fn try_from(value: u8) -> Result<Self, TryFromInterruptError> {
-                    match value {
-                        #(#from_arms)*
-                        _ => Err(TryFromInterruptError(())),
-                    }
-                }
-            }
-        });
+        mod_items.push(interrupt_enum);
     }
 
     if target != Target::None {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -159,7 +159,9 @@ pub fn render(
             #(#variants)*
         }
 
-        unsafe impl ::bare_metal::Nr for Interrupt {
+        pub use ::bare_metal::Nr;
+
+        unsafe impl Nr for Interrupt {
             #[inline]
             fn nr(&self) -> u8 {
                 match *self {


### PR DESCRIPTION
- ~~Derive Debug, Clone, and Copy~~ already done on master
- Reexport the `bare_metal::Nr` trait
- Always implement ~~TryFrom<u8>~~`try_from(u8)` for Interrupt