### PR TITLE
Added util::escape_brackets function to escape unescpad brackets

### DIFF
--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -50,6 +50,8 @@ pub fn render(
                 .description
                 .as_ref()
                 .map(|s| util::respace(s))
+                .as_ref()
+                .map(|s| util::escape_brackets(s))
                 .unwrap_or_else(|| interrupt.name.clone())
         );
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -21,7 +21,7 @@ pub fn render(
 
     let name_pc = Ident::new(&*p.name.to_sanitized_upper_case());
     let address = util::hex(p.base_address);
-    let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
+    let description = util::escape_brackets(util::respace(p.description.as_ref().unwrap_or(&p.name)).as_ref());
 
     let name_sc = Ident::new(&*p.name.to_sanitized_snake_case());
     let (base, derived) = if let Some(base) = p.derived_from.as_ref() {
@@ -95,7 +95,7 @@ pub fn render(
         )?);
     }
 
-    let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
+    let description = util::escape_brackets(util::respace(p.description.as_ref().unwrap_or(&p.name)).as_ref());
     out.push(quote! {
         #[doc = #description]
         pub mod #name_sc {
@@ -396,7 +396,7 @@ fn register_or_cluster_block_stable(
         let comment = &format!(
             "0x{:02x} - {}",
             reg_block_field.offset,
-            util::respace(&reg_block_field.description),
+            util::escape_brackets(util::respace(&reg_block_field.description).as_ref()),
         )[..];
 
         fields.append(quote! {
@@ -473,13 +473,12 @@ fn register_or_cluster_block_nightly(
             let comment = &format!(
                 "0x{:02x} - {}",
                 reg_block_field.offset,
-                util::respace(&reg_block_field.description),
+                util::escape_brackets(util::respace(&reg_block_field.description).as_ref()),
             )[..];
 
             region_fields.append(quote! {
                 #[doc = #comment]
             });
-
 
             reg_block_field.field.to_tokens(&mut region_fields);
             Ident::new(",").to_tokens(&mut region_fields);
@@ -718,7 +717,7 @@ fn cluster_block(
     let mut mod_items: Vec<Tokens> = vec![];
 
     // name_sc needs to take into account array type.
-    let description = util::respace(&c.description);
+    let description = util::escape_brackets(util::respace(&c.description).as_ref());
 
     // Generate the register block.
     let mod_name = match *c {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -31,7 +31,7 @@ pub fn render(
         rsize.next_power_of_two()
     };
     let rty = rsize.to_ty()?;
-    let description = util::respace(&register.description);
+    let description = util::escape_brackets(util::respace(&register.description).as_ref());
 
     let unsafety = unsafety(register.write_constraint.as_ref(), rsize);
 
@@ -728,7 +728,7 @@ pub fn fields(
                     let pc = &v.pc;
                     let sc = &v.sc;
 
-                    let doc = util::respace(&v.doc);
+                    let doc = util::escape_brackets(util::respace(&v.doc).as_ref());
                     if let Some(enum_) = base_pc_w.as_ref() {
                         proxy_items.push(quote! {
                             #[doc = #doc]

--- a/src/util.rs
+++ b/src/util.rs
@@ -137,6 +137,33 @@ pub fn respace(s: &str) -> String {
     s.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
+pub fn escape_brackets(s: &str) -> String {
+    s.split('[')
+        .fold("".to_string(), |acc, x| {
+            if acc == "" {
+                x.to_string()
+            } else {
+                if acc.ends_with("\\") {
+                    acc.to_owned() + "[" + &x.to_string()
+                } else {
+                    acc.to_owned() + "\\[" + &x.to_string()
+                }
+            }
+        })
+        .split(']')
+        .fold("".to_string(), |acc, x| {
+            if acc == "" {
+                x.to_string()
+            } else {
+                if acc.ends_with("\\") {
+                    acc.to_owned() + "[" + &x.to_string()
+                } else {
+                    acc.to_owned() + "\\[" + &x.to_string()
+                }
+            }
+        })
+}
+
 pub fn name_of(register: &Register) -> Cow<str> {
     match *register {
         Register::Single(ref info) => Cow::from(&*info.name),


### PR DESCRIPTION
... in docstrings. This function takes care to not add another level of
escaping in case a docstring contains already escaped brackets.

Closes #232.

Apologies to @Nicoretti for not noticing his PR earlier. However I do
think it is important to not escape properly escaped brackets again,
this is only meant in cases the author failed to do so.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>