### PR TITLE
Only export Interrupt as interrupt when 'rt' is enabled

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -119,6 +119,7 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
             pub use cortex_m::peripheral::Peripherals as CorePeripherals;
             #[cfg(feature = "rt")]
             pub use cortex_m_rt::interrupt;
+            #[cfg(feature = "rt")]
             pub use self::Interrupt as interrupt;
         });
 


### PR DESCRIPTION
It only makes sense to export interrupt if the interrupt! macro is
exported as well, since it's the only thing using it.
Fixes #260 