### PR TITLE
Add support for `Access::WriteOnce` registers

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -82,7 +82,7 @@ pub fn render(
         });
     }
 
-    if access == Access::WriteOnly || access == Access::ReadWrite {
+    if [Access::WriteOnly, Access::WriteOnce, Access::ReadWrite].contains(&access) {
         reg_impl_items.push(quote! {
             /// Writes to the register
             #[inline]
@@ -174,7 +174,7 @@ pub fn render(
         });
     }
 
-    if access == Access::WriteOnly || access == Access::ReadWrite {
+    if [Access::WriteOnly, Access::WriteOnce, Access::ReadWrite].contains(&access) {
         mod_items.push(quote! {
             impl W {
                 #(#w_impl_items)*
@@ -569,7 +569,7 @@ pub fn fields(
         }
     }
 
-    if access == Access::WriteOnly || access == Access::ReadWrite {
+    if [Access::WriteOnly, Access::WriteOnce, Access::ReadWrite].contains(&access) {
         for f in &fs {
             if f.access == Some(Access::ReadOnly) {
                 continue;

--- a/src/util.rs
+++ b/src/util.rs
@@ -183,7 +183,9 @@ pub fn access_of(register: &Register) -> Access {
         if let Some(ref fields) = register.fields {
             if fields.iter().all(|f| f.access == Some(Access::ReadOnly)) {
                 Access::ReadOnly
-            } else if fields.iter().all(|f| f.access == Some(Access::WriteOnly)) {
+            } else if fields.iter().all(|f| f.access == Some(Access::WriteOnce)) {
+                Access::WriteOnce
+            } else if fields.iter().all(|f| f.access == Some(Access::WriteOnly) || f.access == Some(Access::WriteOnce)) {
                 Access::WriteOnly
             } else {
                 Access::ReadWrite


### PR DESCRIPTION
Currently doesn't enforce the write-once nature of the registers, but
treats them as write-only.