### PR TITLE
v0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [v0.14.0] - 2018-12-07
+
+### Added
+
+- On Cortex-M targets the generated code includes a re-export of the
+  `cortex_m_rt::interrupt` attribute, but only when the `rt` feature is enabled.
+
+### Changed
+
+- [breaking-change] on non-Cortex targets Interrupt no longer implements the
+  `TryFrom` trait; it now provides an inherent `try_from` method.
+
+- [breaking-change] for non-Cortex targets svd2rust no longer outputs the
+  generated code to stdout; instead it writes it to a file named `lib.rs`.
+
+- Brackets generated in doc comments are now escaped to prevent warnings on
+  nightly where the compiler tries to interpret bracketed content as links to
+  structs, enums, etc.
+
+### Fixed
+
+- Some bugs around the generation of unions (see `--nightly` flag).
+
 ## [v0.13.1] - 2018-05-16
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ keywords = [
 license = "MIT OR Apache-2.0"
 name = "svd2rust"
 repository = "https://github.com/japaric/svd2rust"
-version = "0.13.1"
+version = "0.14.0"
 
 [[bin]]
 doc = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -60,7 +60,7 @@
 //! ``` toml
 //! [dependencies]
 //! bare-metal = "0.2.0"
-//! cortex-m = "0.6.4"
+//! cortex-m = "0.5.8"
 //! vcell = "0.1.0"
 //!
 //! [dependencies.cortex-m-rt]
@@ -73,27 +73,17 @@
 //!
 //! ## target != cortex-m
 //!
-//! When the target is msp430, riscv or none `svd2rust` will emit all the generated code to stdout.
-//! Like in the cortex-m case we recommend you use `form` and `rustfmt` on the output:
-//!
-//! ``` console
-//! $ svd2rust -i *.svd --target msp430 > lib.rs
-//!
-//! $ rm -rf src
-//!
-//! $ form -i lib.rs -o src/ && rm lib.rs
-//!
-//! $ cargo fmt
-//! ```
+//! When the target is msp430, riscv or none `svd2rust` will emit only the `lib.rs` file. Like in
+//! the cortex-m case we recommend you use `form` and `rustfmt` on the output.
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
 //!
-//! - [`bare-metal`](https://crates.io/crates/bare-metal) v0.1.x
+//! - [`bare-metal`](https://crates.io/crates/bare-metal) v0.2.x
 //! - [`vcell`](https://crates.io/crates/vcell) v0.1.x
 //! - [`msp430`](https://crates.io/crates/msp430) v0.1.x if target = msp430.
 //! - [`msp430-rt`](https://crates.io/crates/msp430-rt) v0.1.x if target = msp430.
-//! - [`riscv`](https://crates.io/crates/riscv) v0.2.x if target = riscv.
-//! - [`riscv-rt`](https://crates.io/crates/riscv-rt) v0.2.x if target = riscv.
+//! - [`riscv`](https://crates.io/crates/riscv) v0.3.x if target = riscv.
+//! - [`riscv-rt`](https://crates.io/crates/riscv-rt) v0.3.x if target = riscv.
 //!
 //! The `*-rt` dependencies must be optional only enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this for an msp430 target:


### PR DESCRIPTION
this commit:

- fixes cortex-m version in documentation (v0.5.x is the latest available
version)

- updates docs to note that svd2rust writes generated code to lib.rs for all
targets

- updates the CHANGELOG

after this lands we can make a new release of svd2rust

r? @rust-embedded/tools
cc @rust-embedded/cortex-m