### PR TITLE
ci: remove rustfmt for speed

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -14,8 +14,6 @@ test_svd() {
 
     mv lib.rs src/lib.rs
 
-    # ignore rustfmt errors
-    rustfmt src/lib.rs || true
     popd
 
     cargo check --manifest-path $td/Cargo.toml


### PR DESCRIPTION
Im trying to find a way to speed up ci as were currently failing due to 50min timeout

It appears its the freescale entry in the matrix, most likely because it has 133 svds that it tests, thats 1/5 of the total svds upstreamed there.

It doesnt actually look like our code is the issue. We seem to run in a second or so. It seems like 
 maybe cargo check and rustfmt split the time. Why rustfmt at all? its probably on average 15 seconds * 133 svds, that would be a dent 

Can someone bors this and see what happens?

cc @therealprof 