### PR TITLE
Add an "ownership" feature to the generated crate

### DIFF
--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -80,7 +80,7 @@ pub fn render(d: &Device, target: &Target, nightly: bool, device_x: &mut String)
         extern crate bare_metal;
         extern crate vcell;
 
-        use core::ops::Deref;
+        use core::ops::{Deref, DerefMut};
         use core::marker::PhantomData;
     });
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -54,6 +54,14 @@ pub fn render(
                 unsafe { &*#name_pc::ptr() }
             }
         }
+
+        impl DerefMut for #name_pc {
+            type Target = #base::RegisterBlock;
+
+            fn deref_mut(&mut self) -> &mut #base::RegisterBlock {
+                unsafe { &*#name_pc::ptr() }
+            }
+        }
     });
 
     // Derived peripherals do not require re-implementation, and will instead

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -51,6 +51,11 @@ pub fn render(
             pub fn ptr_mut() -> *mut #base::RegisterBlock {
                 #address as *mut _
             }
+            /// Destroys the zero sized handle in favor of a `&'static mut` reference to the
+            /// register block
+            pub fn into_static_mut(self) -> &'static mut #base::RegisterBlock {
+                unsafe { &mut*#name_pc::ptr_mut() }
+            }
         }
 
         impl Deref for #name_pc {

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -54,7 +54,7 @@ pub fn render(
             /// Destroys the zero sized handle in favor of a `&'static mut` reference to the
             /// register block
             pub fn into_static_mut(self) -> &'static mut #base::RegisterBlock {
-                unsafe { &mut*#name_pc::ptr_mut() }
+                unsafe { &mut *#name_pc::ptr_mut() }
             }
         }
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -39,6 +39,8 @@ pub fn render(
         pub struct #name_pc { _marker: PhantomData<*const ()> }
 
         unsafe impl Send for #name_pc {}
+        #[cfg(feature = "ownership")]
+        unsafe impl Sync for #name_pc {}
 
         impl #name_pc {
             /// Returns a pointer to the register block

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -47,6 +47,10 @@ pub fn render(
             pub fn ptr() -> *const #base::RegisterBlock {
                 #address as *const _
             }
+            /// Returns a mutable pointer to the register block
+            pub fn ptr_mut() -> *mut #base::RegisterBlock {
+                #address as *mut _
+            }
         }
 
         impl Deref for #name_pc {
@@ -61,7 +65,7 @@ pub fn render(
             type Target = #base::RegisterBlock;
 
             fn deref_mut(&mut self) -> &mut #base::RegisterBlock {
-                unsafe { &*#name_pc::ptr() }
+                unsafe { &mut *#name_pc::ptr_mut() }
             }
         }
     });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,8 +54,9 @@
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
 //! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` >=v0.6.5 and `vcell` v0.1.x. Furthermore
-//! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
-//! `Cargo.toml` of the device crate will look like this:
+//! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled.
+//! Additionally the crate must provide an opt-in "ownership" feature.
+//! The `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
@@ -69,6 +70,7 @@
 //!
 //! [features]
 //! rt = ["cortex-m-rt/device"]
+//! ownership = []
 //! ```
 //!
 //! ## target != cortex-m
@@ -100,6 +102,7 @@
 //!
 //! [features]
 //! rt = ["msp430-rt"]
+//! ownership = []
 //! ```
 //!
 //! # Peripheral API
@@ -219,7 +222,7 @@
 //!     pub fn read(&self) -> R { .. }
 //!
 //!     /// Writes to the register
-//!     pub fn write<F>(&mut self, f: F)
+//!     pub fn write<F>(&self, f: F)
 //!     where
 //!         F: FnOnce(&mut W) -> &mut W,
 //!     {


### PR DESCRIPTION
Activating the feature will make the generated crate require `&mut` references to the registers in order to modify them. This allows us to manage hardware in an owned manner without breaking anyone's code