### PR TITLE
This fixes issue-174 and issue-175 by outputting the proper write fun…

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -106,7 +106,7 @@ main() {
             # test_svd ATSAM3X4C
             # test_svd ATSAM3X4E
             # test_svd ATSAM3X8C
-            # test_svd ATSAM3X8E
+             test_svd ATSAM3X8E
             # test_svd ATSAM4S16B
             # test_svd ATSAM4S16C
             # test_svd ATSAM4S8B

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -96,7 +96,6 @@ pub fn render(
             .reset_value
             .or(defs.reset_value)
             .map(util::hex);
-            //.ok_or_else(|| format!("Register {} has no reset value", register.name))?;
         if let Some(rv) = rv {
             reg_impl_items.push(quote! {
                 /// Writes to the register


### PR DESCRIPTION
…ctions even if the reset-value is missing.

I'm currently working with my Arduino Due and try to get things working. I wrote a quick hello world-application that blinks. All the registers that were needed work with this patch. I did not do much further testing and I'm relatively new to Rust.

I tested with the sam3x8e-SVD-file from the Atmel homepage.

The changes are based on another older pull request, which cannot be applied to the current repository and seem to work fine.
