### PR TITLE
Make lib.rs accessible to dependers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ name = "svd2rust"
 repository = "https://github.com/japaric/svd2rust"
 version = "0.14.0"
 
+[lib]
+name = "svd2rust"
+path = "src/lib.rs"
+
 [[bin]]
 doc = false
 name = "svd2rust"


### PR DESCRIPTION
Hi,
  we are trying to use `svd2rust` from a `build.rs` file. As of now, cargo build-dependencies can't be binaries and using `svd2rust` as a dependency yields an empty crate. `svd2rust` has to be installed manually for our `build.rs` to work.

This is a proposal to fix that. I'm not sure this patch is the right way, but it seems all we need is access to the `generate()` function and we're good to go.

Thanks!
