### PR TITLE
Fix rustc warnings.

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -268,7 +268,7 @@ impl FieldRegions {
         // fold them into the new region we're creating.  There
         // may be multiple regions that we intersect with, so
         // we keep looping to find them all.
-        for (idx, mut f) in self.regions.iter_mut().enumerate() {
+        for (idx, f) in self.regions.iter_mut().enumerate() {
             let f_start = f.offset;
             let f_end = f.end;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,8 @@ mod generate;
 mod util;
 
 use std::fs::File;
-use std::process;
 use std::io::{self, Write};
+use std::process;
 
 use clap::{App, Arg};
 
@@ -46,7 +46,7 @@ fn run() -> Result<()> {
         .arg(
             Arg::with_name("nightly_features")
                 .long("nightly")
-                .help("Enable features only available to nightly rustc")
+                .help("Enable features only available to nightly rustc"),
         )
         .version(concat!(
             env!("CARGO_PKG_VERSION"),
@@ -94,8 +94,6 @@ fn run() -> Result<()> {
 }
 
 fn main() {
-    use std::io::Write;
-
     if let Err(ref e) = run() {
         let stderr = io::stderr();
         let mut stderr = stderr.lock();


### PR DESCRIPTION
This just removes two rustc warnings about an unused `mut` and redundant `use`.