### PR TITLE
Add support for 64-bit registers

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -462,7 +462,7 @@ main() {
             # Test RISC-V K210
             pushd $td
 
-            $cwd/target/$TARGET/release/svd2rust --target riscv -i $td/k210.svd
+            RUST_BACKTRACE=1 $cwd/target/$TARGET/release/svd2rust --target riscv -i $td/k210.svd
             mv $td/lib.rs $td/src/lib.rs
             rustfmt $td/src/lib.rs || true
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -427,9 +427,12 @@ main() {
                 cd $td &&
                     curl -LO \
                          https://github.com/pftbest/msp430g2553/raw/v0.1.0/msp430g2553.svd
-                 cd $td &&
-                     curl -LO \
-                          https://raw.githubusercontent.com/riscv-rust/e310x/master/e310x.svd
+                cd $td &&
+                    curl -LO \
+                         https://raw.githubusercontent.com/riscv-rust/e310x/master/e310x.svd
+                cd $td &&
+                    curl -LO \
+                         https://raw.githubusercontent.com/riscv-rust/k210-pac/master/k210.svd
             )
 
             local cwd=$(pwd)
@@ -445,10 +448,21 @@ main() {
 
             cargo check --manifest-path $td/Cargo.toml
 
-            # Test RISC-V
+            # Test RISC-V FE310
             pushd $td
 
             $cwd/target/$TARGET/release/svd2rust --target riscv -i $td/e310x.svd
+            mv $td/lib.rs $td/src/lib.rs
+            rustfmt $td/src/lib.rs || true
+
+            popd
+
+            cargo check --manifest-path $td/Cargo.toml
+
+            # Test RISC-V K210
+            pushd $td
+
+            $cwd/target/$TARGET/release/svd2rust --target riscv -i $td/k210.svd
             mv $td/lib.rs $td/src/lib.rs
             rustfmt $td/src/lib.rs || true
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -267,6 +267,7 @@ impl U32Ext for u32 {
             2...8 => Ident::new("u8"),
             9...16 => Ident::new("u16"),
             17...32 => Ident::new("u32"),
+            33...64 => Ident::new("u64"),
             _ => Err(format!(
                 "can't convert {} bits into a Rust integral type",
                 *self
@@ -280,6 +281,7 @@ impl U32Ext for u32 {
             2...8 => 8,
             9...16 => 16,
             17...32 => 32,
+            33...64 => 64,
             _ => Err(format!(
                 "can't convert {} bits into a Rust integral type width",
                 *self


### PR DESCRIPTION
Some registers on K210 chip are 64-bit, so it's better to declare them as u64 in SVD for the reasons mentioned here: https://github.com/riscv-rust/k210-pac/issues/1#issuecomment-489311245
At the moment, svd2rust forbids 64-bit register declarations. This PR fixes this.

This change can cause silent bugs on platforms without 64-bit memory access operations due to the need for proper access sequence to 64-bit registers with two 32-bit accesses.

Closes https://github.com/rust-embedded/svd2rust/issues/289