### PR TITLE
CI: use Cargo instead of Cross

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,12 +36,12 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=OTHER
       rust: nightly
 
-    # Stable, used to produce binary relreases
-    # Linux
+    # Stable, used to produce binary releases
+    # Linux; we do the MUSL builds locally and then upload the binaries
     # - env: TARGET=i686-unknown-linux-gnu
-    - env: TARGET=i686-unknown-linux-musl
+    # - env: TARGET=i686-unknown-linux-musl
     # - env: TARGET=x86_64-unknown-linux-gnu
-    - env: TARGET=x86_64-unknown-linux-musl
+    # - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
     - env: TARGET=i686-apple-darwin

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,10 +36,11 @@ matrix:
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=OTHER
       rust: nightly
 
+    # Stable, used to produce binary relreases
     # Linux
-    - env: TARGET=i686-unknown-linux-gnu
+    # - env: TARGET=i686-unknown-linux-gnu
     - env: TARGET=i686-unknown-linux-musl
-    - env: TARGET=x86_64-unknown-linux-gnu
+    # - env: TARGET=x86_64-unknown-linux-gnu
     - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -1,13 +1,7 @@
 set -euxo pipefail
 
 main() {
-    if [ $TARGET = x86_64-pc-windows-msvc ]; then
-        cargo=cargo
-    else
-        cargo=cross
-    fi
-
-    $cargo rustc --bin svd2rust --target $TARGET --release -- -C lto
+    cargo rustc --bin svd2rust --target $TARGET --release -- -C lto
 
     rm -rf stage
     mkdir stage

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -10,16 +10,16 @@ main() {
         sort=gsort
     fi
 
-    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
-                    | cut -d/ -f3 \
-                    | grep -E '^v[0-9.]+$' \
-                    | $sort --version-sort \
-                    | tail -n1)
-    curl -LSfs https://japaric.github.io/trust/install.sh | \
-        sh -s -- \
-           --force \
-           --git japaric/cross \
-           --tag $tag
+    # local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+    #                 | cut -d/ -f3 \
+    #                 | grep -E '^v[0-9.]+$' \
+    #                 | $sort --version-sort \
+    #                 | tail -n1)
+    # curl -LSfs https://japaric.github.io/trust/install.sh | \
+    #     sh -s -- \
+    #        --force \
+    #        --git japaric/cross \
+    #        --tag $tag
 
     rustup component add rustfmt-preview
 }

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -21,6 +21,7 @@ main() {
     #        --git japaric/cross \
     #        --tag $tag
 
+    rustup target add $TARGET
     rustup component add rustfmt-preview
 }
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -29,13 +29,13 @@ main() {
         return
     fi
 
-    cross check --target $TARGET
+    cargo check --target $TARGET
 
     if [ -z ${VENDOR-} ]; then
         return
     fi
 
-    cross build --target $TARGET --release
+    cargo build --target $TARGET --release
 
     case $TRAVIS_OS_NAME in
         linux)


### PR DESCRIPTION
this removes the Linux GNU targets used to produce binaries but we still have
the MUSL builds which will work everywhere because they statically linked
binaries