### PR TITLE
Remove some noise in the generated code

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -49,8 +49,8 @@ pub fn render(
                 for<'w> F: FnOnce(&R, &'w mut W) -> &'w mut W
             {
                 let bits = self.register.get();
-                let r = R { bits: bits };
-                let mut w = W { bits: bits };
+                let r = R { bits };
+                let mut w = W { bits };
                 f(&r, &mut w);
                 self.register.set(w.bits);
             }


### PR DESCRIPTION
Struct initialisations don't need to repeat field names if they're equal
to a local variable.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>