### PR TITLE
Remove Mask offset consts

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -516,7 +516,7 @@ pub fn fields(
                     #[doc = #description]
                     #[inline]
                     pub fn #sc(&self) -> #pc_r {
-                        let bits = { #value };
+                        let bits = #value;
                         #pc_r { bits }
                     }
                 });

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -257,7 +257,7 @@ pub fn fields(
                 access: f.access,
                 evs: &f.enumerated_values,
                 sc: Ident::new(&*sc),
-                mask: util::hex_or_bool((((1 as u64) << width) - 1) as u32, width),
+                mask: util::hex((((1 as u64) << width) - 1) as u32),
                 name: &f.name,
                 offset: util::unsuffixed(u64::from(f.bit_range.offset)),
                 ty: width.to_ty()?,
@@ -285,7 +285,7 @@ pub fn fields(
                 quote! { as #fty }
             };
             let value = quote! {
-                ((self.bits >> #offset) & #mask as #rty) #cast
+                ((self.bits >> #offset) & #mask) #cast
             };
 
             if let Some((evs, base)) = lookup(
@@ -760,8 +760,8 @@ pub fn fields(
                 /// Writes raw bits to the field
                 #[inline]
                 pub #unsafety fn #bits(self, value: #fty) -> &'a mut W {
-                    self.w.bits &= !((#mask as #rty) << #offset);
-                    self.w.bits |= ((value & #mask) as #rty) << #offset;
+                    self.w.bits &= !(#mask << #offset);
+                    self.w.bits |= ((value as #rty) & #mask) << #offset;
                     self.w
                 }
             });

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -285,10 +285,7 @@ pub fn fields(
                 quote! { as #fty }
             };
             let value = quote! {
-                const MASK: #fty = #mask;
-                const OFFSET: u8 = #offset;
-
-                ((self.bits >> OFFSET) & MASK as #rty) #cast
+                ((self.bits >> #offset) & #mask as #rty) #cast
             };
 
             if let Some((evs, base)) = lookup(
@@ -763,11 +760,8 @@ pub fn fields(
                 /// Writes raw bits to the field
                 #[inline]
                 pub #unsafety fn #bits(self, value: #fty) -> &'a mut W {
-                    const MASK: #fty = #mask;
-                    const OFFSET: u8 = #offset;
-
-                    self.w.bits &= !((MASK as #rty) << OFFSET);
-                    self.w.bits |= ((value & MASK) as #rty) << OFFSET;
+                    self.w.bits &= !((#mask as #rty) << #offset);
+                    self.w.bits |= ((value & #mask) as #rty) << #offset;
                     self.w
                 }
             });

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -107,7 +107,7 @@ pub fn render(
         w_impl_items.push(quote! {
             /// Reset value of the register
             #[inline]
-            pub fn reset_value() -> W {
+            pub const fn reset_value() -> W {
                 W { bits: #rv }
             }
 


### PR DESCRIPTION
cc @therealprof 

Example:
```rust
pub unsafe fn bits(self, value: u8) -> &'a mut W {
    self.w.bits &= !(0x1f << 8);
    self.w.bits |= ((value as u32) & 0x1f) << 8;
    self.w
}

pub fn dbl(&self) -> DBLR {
    let bits = ((self.bits >> 8) & 0x1f) as u8;
    DBLR { bits }
}
```