### PR TITLE
DRY: We can just use &Self::Target for deref impl

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -62,7 +62,7 @@ pub fn render(
         impl Deref for #name_pc {
             type Target = #base::RegisterBlock;
 
-            fn deref(&self) -> &#base::RegisterBlock {
+            fn deref(&self) -> &Self::Target {
                 unsafe { &*#name_pc::ptr() }
             }
         }


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>