### PR TITLE
Also always inline set_bit/clear bit

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -741,11 +741,13 @@ pub fn fields(
             if width == 1 {
                 proxy_items.push(quote! {
                     ///Sets the field bit
+                    #[inline(always)]
                     pub #unsafety fn set_bit(self) -> &'a mut W {
                         self.bit(true)
                     }
 
                     ///Clears the field bit
+                    #[inline(always)]
                     pub #unsafety fn clear_bit(self) -> &'a mut W {
                         self.bit(false)
                     }


### PR DESCRIPTION
Reduces build size by quite a bit in dev builds but to my surprise also
helps in optimised builds using set_bit/clear_bit indirectly via HAL
impls.

Closes #334

Signed-off-by: Daniel Egger <daniel@eggers-club.de>