### PR TITLE
Don't use quote concats to munge the Vec<Tokens> into one huge string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Correct handling of cluster size tag
+### Added
 
 - Support of 64-bit fields
+
+### Changed
+
+- Break ultra-long single line output into multiple lines for better usability
+
+### Fixed
+
+- Correct handling of cluster size tag
 
 ## [v0.15.0] - 2019-07-25
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -185,11 +185,23 @@ pub fn render(
 
     let description =
         util::escape_brackets(util::respace(p.description.as_ref().unwrap_or(&p.name)).as_ref());
+
+    let open = Ident::from("{");
+    let close = Ident::from("}");
+
     out.push(quote! {
         #[doc = #description]
-        pub mod #name_sc {
-            #(#mod_items)*
-        }
+        pub mod #name_sc #open
+    });
+
+    for item in mod_items {
+        out.push(quote! {
+            #item
+        });
+    }
+
+    out.push(quote! {
+       #close
     });
 
     Ok(out)


### PR DESCRIPTION
By manually iterating over the Vec<Token> when writing out to lib.rs we
can insert new lines after each token. In addition we split up some
of the inner quote repetition operator uses into regular iteration, too,
to generate individual Tokens. This changes a typical lib.rs file from 2
to 20k lines (200k after rustfmt) which should help a lot to prevent
tools (like rust when errors happen) from going insane and makes the
files a lot more directly usable without having to rustfmt all the time.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>