### PR TITLE
add variant to reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `variant()` method for field reader and `Variant` enum for fields with reserved values
+
 ## [v0.15.2] - 2019-07-29
 
 - No changes, just fixing the metadata since crates.io didn't like the keywords

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -74,6 +74,17 @@ pub fn render() -> Result<Vec<Tokens>> {
         }
     });
 
+    generic_items.push(quote! {
+        ///Used if enumerated values cover not the whole range
+        #[derive(Clone,Copy,PartialEq)]
+        pub enum Variant<U, T> {
+            ///Expected variant
+            Val(T),
+            ///Raw bits
+            Res(U),
+        }
+    });
+
     code.push(quote! {
         #[allow(unused_imports)]
         use generic::*;


### PR DESCRIPTION
r? @therealprof 

Restore access to `enum`'s by `variant` method that return `enum FIELD` when possible or `Variant`.

Also replace `_to_bits` method in writer with trait.
So now enums for reader and writer are identical (when they don't use different values for read and write) and can be replaced by one.

See #353 .