### PR TITLE
separate generic mod

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,4 +40,7 @@ inflections = "1.1.0"
 log = { version = "~0.4", features = ["std"] }
 quote = "0.3.15"
 svd-parser = "0.7"
-syn = "0.11.11"
+
+[dependencies.syn]
+version = "0.11.11"
+features = ["full"]

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -1,234 +1,190 @@
-use quote::Tokens;
+use core::marker;
 
-use crate::errors::*;
+///This trait shows that register has `read` method
+///
+///Registers marked with `Writable` can be also `modify`'ed
+pub trait Readable {}
 
-/// Generates generic bit munging code
-pub fn render() -> Result<Vec<Tokens>> {
-    let mut code = vec![];
-    let mut generic_items = vec![];
+///This trait shows that register has `write`, `write_with_zero` and `reset` method
+///
+///Registers marked with `Readable` can be also `modify`'ed
+pub trait Writable {}
 
-    generic_items.push(quote! {
-        use core::marker;
+///Reset value of the register
+///
+///This value is initial value for `write` method.
+///It can be also directly writed to register by `reset` method.
+pub trait ResetValue {
+    ///Register size
+    type Type;
+    ///Reset value of the register
+    fn reset_value() -> Self::Type;
+}
 
-        ///This trait shows that register has `read` method
-        ///
-        ///Registers marked with `Writable` can be also `modify`'ed
-        pub trait Readable {}
+///Converting enumerated values to bits
+pub trait ToBits<N> {
+    ///Conversion method
+    fn _bits(&self) -> N;
+}
 
-        ///This trait shows that register has `write`, `write_with_zero` and `reset` method
-        ///
-        ///Registers marked with `Readable` can be also `modify`'ed
-        pub trait Writable {}
+///This structure provides volatile access to register
+pub struct Reg<U, REG> {
+    register: vcell::VolatileCell<U>,
+    _marker: marker::PhantomData<REG>,
+}
 
-        ///Reset value of the register
-        ///
-        ///This value is initial value for `write` method.
-        ///It can be also directly writed to register by `reset` method.
-        pub trait ResetValue {
-            ///Register size
-            type Type;
-            ///Reset value of the register
-            fn reset_value() -> Self::Type;
+unsafe impl<U: Send, REG> Send for Reg<U, REG> { }
+
+impl<U, REG> Reg<U, REG>
+where
+    Self: Readable,
+    U: Copy
+{
+    ///Reads the contents of `Readable` register
+    ///
+    ///See [reading](https://rust-embedded.github.io/book/start/registers.html#reading) in book.
+    #[inline(always)]
+    pub fn read(&self) -> R<U, Self> {
+        R {bits: self.register.get(), _reg: marker::PhantomData}
+    }
+}
+
+impl<U, REG> Reg<U, REG>
+where
+    Self: ResetValue<Type=U> + Writable,
+    U: Copy,
+{
+    ///Writes the reset value to `Writable` register
+    #[inline(always)]
+    pub fn reset(&self) {
+        self.register.set(Self::reset_value())
+    }
+}
+
+impl<U, REG> Reg<U, REG>
+where
+    Self: ResetValue<Type=U> + Writable,
+    U: Copy
+{
+    ///Writes bits to `Writable` register
+    ///
+    ///See [writing](https://rust-embedded.github.io/book/start/registers.html#writing) in book.
+    #[inline(always)]
+    pub fn write<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>
+    {
+        self.register.set(f(&mut W {bits: Self::reset_value(), _reg: marker::PhantomData}).bits);
+    }
+}
+
+impl<U, REG> Reg<U, REG>
+where
+    Self: Writable,
+    U: Copy + Default
+{
+    ///Writes Zero to `Writable` register
+    #[inline(always)]
+    pub fn write_with_zero<F>(&self, f: F)
+    where
+        F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>
+    {
+        self.register.set(f(&mut W {bits: U::default(), _reg: marker::PhantomData }).bits);
+    }
+}
+
+impl<U, REG> Reg<U, REG>
+where
+    Self: Readable + Writable,
+    U: Copy,
+{
+    ///Modifies the contents of the register
+    ///
+    ///See [modifying](https://rust-embedded.github.io/book/start/registers.html#modifying) in book.
+    #[inline(always)]
+    pub fn modify<F>(&self, f: F)
+    where
+        for<'w> F: FnOnce(&R<U, Self>, &'w mut W<U, Self>) -> &'w mut W<U, Self>
+    {
+        let bits = self.register.get();
+        self.register.set(f(&R {bits, _reg: marker::PhantomData}, &mut W {bits, _reg: marker::PhantomData}).bits);
+    }
+}
+
+///Register/field reader
+pub struct R<U, T> {
+    pub(crate) bits: U,
+    _reg: marker::PhantomData<T>,
+}
+
+impl<U, T> R<U, T>
+where
+    U: Copy
+{
+    ///Create new instance of reader
+    #[inline(always)]
+    pub(crate) fn new(bits: U) -> Self {
+        Self {
+            bits,
+            _reg: marker::PhantomData,
         }
+    }
+    ///Read raw bits from register/field
+    #[inline(always)]
+    pub fn bits(&self) -> U {
+        self.bits
+    }
+}
 
-        ///Converting enumerated values to bits
-        pub trait ToBits<N> {
-            ///Conversion method
-            fn _bits(&self) -> N;
-        }
-    });
+impl<U, T, FI> PartialEq<FI> for R<U, T>
+where
+    U: PartialEq,
+    FI: ToBits<U>
+{
+    fn eq(&self, other: &FI) -> bool {
+        self.bits.eq(&other._bits())
+    }
+}
 
-    generic_items.push(quote! {
-        ///This structure provides volatile access to register
-        pub struct Reg<U, REG> {
-            register: vcell::VolatileCell<U>,
-            _marker: marker::PhantomData<REG>,
-        }
+impl<FI> R<bool, FI> {
+    ///Value of the field as raw bits
+    #[inline(always)]
+    pub fn bit(&self) -> bool {
+        self.bits
+    }
+    ///Returns `true` if the bit is clear (0)
+    #[inline(always)]
+    pub fn bit_is_clear(&self) -> bool {
+        !self.bit()
+    }
+    ///Returns `true` if the bit is set (1)
+    #[inline(always)]
+    pub fn bit_is_set(&self) -> bool {
+        self.bit()
+    }
+}
 
-        unsafe impl<U: Send, REG> Send for Reg<U, REG> { }
+///Register writer
+pub struct W<U, REG> {
+    ///Writable bits
+    pub bits: U,
+    _reg: marker::PhantomData<REG>,
+}
 
-        impl<U, REG> Reg<U, REG>
-        where
-            Self: Readable,
-            U: Copy
-        {
-            ///Reads the contents of `Readable` register
-            ///
-            ///See [reading](https://rust-embedded.github.io/book/start/registers.html#reading) in book.
-            #[inline(always)]
-            pub fn read(&self) -> R<U, Self> {
-                R {bits: self.register.get(), _reg: marker::PhantomData}
-            }
-        }
+impl<U, REG> W<U, REG> {
+    ///Writes raw bits to the register
+    #[inline(always)]
+    pub fn bits(&mut self, bits: U) -> &mut Self {
+        self.bits = bits;
+        self
+    }
+}
 
-        impl<U, REG> Reg<U, REG>
-        where
-            Self: ResetValue<Type=U> + Writable,
-            U: Copy,
-        {
-            ///Writes the reset value to `Writable` register
-            #[inline(always)]
-            pub fn reset(&self) {
-                self.register.set(Self::reset_value())
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<U, REG> Reg<U, REG>
-        where
-            Self: ResetValue<Type=U> + Writable,
-            U: Copy
-        {
-            ///Writes bits to `Writable` register
-            ///
-            ///See [writing](https://rust-embedded.github.io/book/start/registers.html#writing) in book.
-            #[inline(always)]
-            pub fn write<F>(&self, f: F)
-            where
-                F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>
-            {
-                self.register.set(f(&mut W {bits: Self::reset_value(), _reg: marker::PhantomData}).bits);
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<U, REG> Reg<U, REG>
-        where
-            Self: Writable,
-            U: Copy + Default
-        {
-            ///Writes Zero to `Writable` register
-            #[inline(always)]
-            pub fn write_with_zero<F>(&self, f: F)
-            where
-                F: FnOnce(&mut W<U, Self>) -> &mut W<U, Self>
-            {
-                self.register.set(f(&mut W {bits: U::default(), _reg: marker::PhantomData }).bits);
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<U, REG> Reg<U, REG>
-        where
-            Self: Readable + Writable,
-            U: Copy,
-        {
-            ///Modifies the contents of the register
-            ///
-            ///See [modifying](https://rust-embedded.github.io/book/start/registers.html#modifying) in book.
-            #[inline(always)]
-            pub fn modify<F>(&self, f: F)
-            where
-                for<'w> F: FnOnce(&R<U, Self>, &'w mut W<U, Self>) -> &'w mut W<U, Self>
-            {
-                let bits = self.register.get();
-                self.register.set(f(&R {bits, _reg: marker::PhantomData}, &mut W {bits, _reg: marker::PhantomData}).bits);
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        ///Register/field reader
-        pub struct R<U, T> {
-            pub(crate) bits: U,
-            _reg: marker::PhantomData<T>,
-        }
-
-        impl<U, T> R<U, T>
-        where
-            U: Copy
-        {
-            ///Create new instance of reader
-            #[inline(always)]
-            pub(crate) fn new(bits: U) -> Self {
-                Self {
-                    bits,
-                    _reg: marker::PhantomData,
-                }
-            }
-            ///Read raw bits from register/field
-            #[inline(always)]
-            pub fn bits(&self) -> U {
-                self.bits
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<U, T, FI> PartialEq<FI> for R<U, T>
-        where
-            U: PartialEq,
-            FI: ToBits<U>
-        {
-            fn eq(&self, other: &FI) -> bool {
-                self.bits.eq(&other._bits())
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<FI> R<bool, FI> {
-            ///Value of the field as raw bits
-            #[inline(always)]
-            pub fn bit(&self) -> bool {
-                self.bits
-            }
-            ///Returns `true` if the bit is clear (0)
-            #[inline(always)]
-            pub fn bit_is_clear(&self) -> bool {
-                !self.bit()
-            }
-            ///Returns `true` if the bit is set (1)
-            #[inline(always)]
-            pub fn bit_is_set(&self) -> bool {
-                self.bit()
-            }
-        }
-    });
-
-    generic_items.push(quote! {
-        ///Register writer
-        pub struct W<U, REG> {
-            ///Writable bits
-            pub bits: U,
-            _reg: marker::PhantomData<REG>,
-        }
-    });
-
-    generic_items.push(quote! {
-        impl<U, REG> W<U, REG> {
-            ///Writes raw bits to the register
-            #[inline(always)]
-            pub fn bits(&mut self, bits: U) -> &mut Self {
-                self.bits = bits;
-                self
-            }
-        }
-    });
-
-
-    generic_items.push(quote! {
-        ///Used if enumerated values cover not the whole range
-        #[derive(Clone,Copy,PartialEq)]
-        pub enum Variant<U, T> {
-            ///Expected variant
-            Val(T),
-            ///Raw bits
-            Res(U),
-        }
-    });
-
-    code.push(quote! {
-        #[allow(unused_imports)]
-        use generic::*;
-        ///Common register and bit access and modify traits
-        pub mod generic {
-            #(#generic_items)*
-        }
-    });
-
-    Ok(code)
+///Used if enumerated values cover not the whole range
+#[derive(Clone,Copy,PartialEq)]
+pub enum Variant<U, T> {
+    ///Expected variant
+    Val(T),
+    ///Raw bits
+    Res(U),
 }

--- a/src/generate/mod.rs
+++ b/src/generate/mod.rs
@@ -1,5 +1,4 @@
 pub mod device;
-pub mod generic;
 pub mod interrupt;
 pub mod peripheral;
 pub mod register;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -462,7 +462,7 @@ pub fn generate(xml: &str, target: Target, nightly: bool) -> Result<Generation> 
 
     let device = svd::parse(xml).unwrap(); //TODO(AJM)
     let mut device_x = String::new();
-    let items = generate::device::render(&device, target, nightly, &mut device_x)
+    let items = generate::device::render(&device, target, nightly, false, &mut device_x)
         .or(Err(SvdError::Render))?;
 
     let mut lib_rs = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,12 @@ fn run() -> Result<()> {
                 .help("Enable features only available to nightly rustc"),
         )
         .arg(
+            Arg::with_name("generic_mod")
+                .long("generic_mod")
+                .short("g")
+                .help("Push generic mod in separate file"),
+        )
+        .arg(
             Arg::with_name("log_level")
                 .long("log")
                 .short("l")
@@ -90,8 +96,10 @@ fn run() -> Result<()> {
 
     let nightly = matches.is_present("nightly_features");
 
+    let generic_mod = matches.is_present("generic_mod");
+
     let mut device_x = String::new();
-    let items = generate::device::render(&device, target, nightly, &mut device_x)?;
+    let items = generate::device::render(&device, target, nightly, generic_mod, &mut device_x)?;
     let mut file = File::create("lib.rs").expect("Couldn't create lib.rs file");
 
     for item in items {


### PR DESCRIPTION
Adds option `-g` which when enabled store contents of `generic.rs` in separate file.

It's useful for common crates like `stm32f1` where one crate for several `pac`s.

Uses `syn::parse` instead of vector of `quote!`.