### PR TITLE
Fix crash on missing register description in SVD file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Handling of missing register description (optional field)
+
 ## [v0.16.0] - 2019-08-05
 
 ### Added

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -679,7 +679,7 @@ fn expand_register(
     match register {
         Register::Single(info) => register_expanded.push(RegisterBlockField {
             field: convert_svd_register(register, name),
-            description: info.description.clone().unwrap(),
+            description: info.description.clone().unwrap_or_else(|| "".to_string()),
             offset: info.address_offset,
             size: register_size,
         }),
@@ -699,7 +699,7 @@ fn expand_register(
             if array_convertible {
                 register_expanded.push(RegisterBlockField {
                     field: convert_svd_register(&register, name),
-                    description: info.description.clone().unwrap(),
+                    description: info.description.clone().unwrap_or_else(|| "".to_string()),
                     offset: info.address_offset,
                     size: register_size * array_info.dim,
                 });
@@ -707,7 +707,7 @@ fn expand_register(
                 for (field_num, field) in expand_svd_register(register, name).iter().enumerate() {
                     register_expanded.push(RegisterBlockField {
                         field: field.clone(),
-                        description: info.description.clone().unwrap(),
+                        description: info.description.clone().unwrap_or_else(|| "".to_string()),
                         offset: info.address_offset + field_num as u32 * array_info.dim_increment,
                         size: register_size,
                     });

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -3,6 +3,7 @@ use crate::svd::{
     Usage, WriteConstraint,
 };
 use cast::u64;
+use log::warn;
 use quote::Tokens;
 use syn::Ident;
 
@@ -33,8 +34,13 @@ pub fn render(
         rsize.next_power_of_two()
     };
     let rty = rsize.to_ty()?;
-    let description =
-        util::escape_brackets(util::respace(&register.description.clone().unwrap()).as_ref());
+    let description = util::escape_brackets(
+        util::respace(&register.description.clone().unwrap_or_else(|| {
+            warn!("Missing description for register {}", register.name);
+            "".to_string()
+        }))
+        .as_ref(),
+    );
 
     let mut mod_items = vec![];
     let mut r_impl_items = vec![];


### PR DESCRIPTION
SVDs available for DA1469x from https://www.keil.com/dd2/pack have few registers with missing `<description>` and this causes svd2rust to crash.

This PR enables to continue with a dummy description  and print name of the
problematic register instead of just bailing out.