### PR TITLE
register Defaults -> svd-parser

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ error-chain = "0.11.0"
 inflections = "1.1.0"
 log = { version = "~0.4", features = ["std"] }
 quote = "0.3.15"
-svd-parser = "0.7"
+svd-parser = {git = "https://github.com/burrbull/svd", branch = "periph-size"}
 
 [dependencies.syn]
 version = "0.11.11"

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -162,7 +162,7 @@ pub fn render(
             continue;
         }
 
-        out.extend(peripheral::render(p, &d.peripherals, &d.defaults, nightly)?);
+        out.extend(peripheral::render(p, &d.peripherals, nightly)?);
 
         if p.registers
             .as_ref()

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -1,5 +1,5 @@
 use crate::svd::{
-    Access, BitRange, Defaults, EnumeratedValues, Field, Peripheral, Register, RegisterCluster,
+    Access, BitRange, EnumeratedValues, Field, Peripheral, Register, RegisterCluster,
     Usage, WriteConstraint,
 };
 use cast::u64;
@@ -15,7 +15,6 @@ pub fn render(
     all_registers: &[&Register],
     peripheral: &Peripheral,
     all_peripherals: &[Peripheral],
-    defs: &Defaults,
 ) -> Result<Vec<Tokens>> {
     let access = util::access_of(register);
     let name = util::name_of(register);
@@ -24,7 +23,6 @@ pub fn render(
     let name_sc = Ident::from(&*name.to_sanitized_snake_case());
     let rsize = register
         .size
-        .or(defs.size)
         .ok_or_else(|| format!("Register {} has no `size` field", register.name))?;
     let rsize = if rsize < 8 {
         8
@@ -67,7 +65,6 @@ pub fn render(
         });
         let res_val = register
             .reset_value
-            .or(defs.reset_value)
             .map(|v| util::hex(v as u64));
         if let Some(rv) = res_val {
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);


### PR DESCRIPTION
r? @therealprof 

Depends on https://github.com/japaric/svd/pull/73

I decided it is more appropriate to move the forwarding of `Defaults` (common `size`, `access`, etc.) to the parsing stage.

This simplify handling of parsed device.
Also I'm sure this fix a lot of bugs. (for example https://github.com/riscv-rust/k210-pac/blob/c70d429c45e25f15a5bddcd6c25d4470eab66842/k210.svd#L1327)