### PR TITLE
Sanitize names from dashes

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -11,7 +11,7 @@ pub const BITS_PER_BYTE: u32 = 8;
 
 /// List of chars that some vendors use in their peripheral/field names but
 /// that are not valid in Rust ident
-const BLACKLIST_CHARS: &[char] = &['(', ')', '[', ']', '/', ' '];
+const BLACKLIST_CHARS: &[char] = &['(', ')', '[', ']', '/', ' ', '-'];
 
 #[derive(Clone, Copy, PartialEq)]
 pub enum Target {


### PR DESCRIPTION
Example: "normally or power-up" gave "NORMALLYORPOWER-UP" which doesn't work.