### PR TITLE
Make interrupt vector for MSP430 16 bits instead of 32 bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Improve field enum docs
 
+- Change interrupt vector size for MSP430 to 16 bits from 32 bits
+
 ### Changed
 
 - Bump dependencies: `syn`, `quote` and `proc_macro2` v1.0.

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
 use std::fmt::Write;
 
-use cast::u64;
-use proc_macro2::{TokenStream, Ident, Span};
 use crate::svd::Peripheral;
+use cast::u64;
+use proc_macro2::{Ident, Span, TokenStream};
 
 use crate::errors::*;
 use crate::util::{self, ToSanitizedUpperCase};
@@ -133,7 +133,7 @@ pub fn render(
                 #[doc(hidden)]
                 pub union Vector {
                     _handler: unsafe extern "msp430-interrupt" fn(),
-                    _reserved: u32,
+                    _reserved: u16,
                 }
 
                 #[cfg(feature = "rt")]


### PR DESCRIPTION
The old 32 bit vectors caused linker errors when building for MSP430. This change fixes the errors.