### PR TITLE
Add `#[inline(always)]` to deref implementations.

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -66,6 +66,7 @@ pub fn render(
         impl Deref for #name_pc {
             type Target = #base::RegisterBlock;
 
+            #[inline(always)]
             fn deref(&self) -> &Self::Target {
                 unsafe { &*#name_pc::ptr() }
             }


### PR DESCRIPTION
See #287.