### PR TITLE
use repr(fty) for enums

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Enum items now associated with values (C-style), enums annotated with `repr(fty)`
 - Bump `svd-parser` dependency (0.8.1)
 
 ## [v0.16.1] - 2019-08-17

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -636,13 +636,11 @@ impl Variant {
 fn add_from_variants(mod_items: &mut Vec<TokenStream>, variants: &Vec<Variant>, pc: &Ident, f: &F, desc: &str, reset_value: Option<u64>) {
     let fty = &f.ty;
 
-    let mut repr = quote! { #[repr(#fty)] };
-    let mut cast = quote! { variant as _ };
-
-    if f.ty == "bool" {
-        repr = quote! { };
-        cast = quote! { variant as u8 != 0 };
-    }
+    let (repr, cast) = if f.ty == "bool" {
+        (quote! { }, quote! { variant as u8 != 0 })
+    } else {
+        (quote! { #[repr(#fty)] }, quote! { variant as _ })
+    };
 
     let vars = variants
         .iter()


### PR DESCRIPTION
enums are now in C-style with `#repr(..)`

Should slightly reduce code size in debug mode when enums are used.

r? @Disasm
cc @therealprof 