### PR TITLE
Ignore non snake case types that can exist in SVD files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Enum items now associated with values (C-style), enums annotated with `repr(fty)`
 - Bump `svd-parser` dependency (0.8.1)
+- Switched from denying all warnings to only a subset.
 
 ## [v0.16.1] - 2019-08-17
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -45,9 +45,29 @@ pub fn render(
 
     out.push(quote! {
         #![doc = #doc]
+        // Deny a subset of warnings
+        #![deny(const_err)]
+        #![deny(dead_code)]
+        #![deny(improper_ctypes)]
+        #![deny(legacy_directory_ownership)]
         #![deny(missing_docs)]
-        #![deny(warnings)]
+        #![deny(no_mangle_generic_items)]
+        #![deny(non_shorthand_field_patterns)]
+        #![deny(overflowing_literals)]
+        #![deny(path_statements)]
+        #![deny(patterns_in_fns_without_body)]
+        #![deny(plugin_as_library)]
+        #![deny(private_in_public)]
+        #![deny(safe_extern_statics)]
+        #![deny(unconditional_recursion)]
+        #![deny(unions_with_drop_fields)]
+        #![deny(unused_allocation)]
+        #![deny(unused_comparisons)]
+        #![deny(unused_parens)]
+        #![deny(while_true)]
+        // Explicitly allow a few warnings that may be verbose
         #![allow(non_camel_case_types)]
+        #![allow(non_snake_case)]
         #![no_std]
     });
 


### PR DESCRIPTION
Hi! :wave: Thanks for this awesome project!

I've run into a build error generating bindings for the [psoc6-pac](https://github.com/psoc-rs/psoc6-pac). Here's a example of one of the many build failures:

```
error: structure field `data_list_sent_update__status` should have a snake case name
   --> src/ble.rs:187:9
    |
187 |     pub data_list_sent_update__status: self::blell::DATA_LIST_SENT_UPDATE__STATUS,
    |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: convert the identifier to snake case: `data_list_sent_update_status`
```

This issue is caused by `#![deny(warnings)]` and should be fixed by adding the `#![allow(non_snake_case)]` exception. There may be alternative fixes, I'm open to suggestions! 
