### PR TITLE
Simplify Interrupt::nr

### DIFF
--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -149,12 +149,13 @@ pub fn render(
     let interrupt_enum = quote! {
         ///Enumeration of all the interrupts
         #[derive(Copy, Clone, Debug)]
+        #[repr(u8)]
         pub enum Interrupt {
             #(#variants)*
         }
 
         unsafe impl bare_metal::Nr for Interrupt {
-            #[inline]
+            #[inline(always)]
             fn nr(&self) -> u8 {
                 *self as u8
             }

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -146,10 +146,11 @@ pub fn render(
         Target::None => {}
     }
 
-    let enum_repr = if variants.is_empty() {
-        quote!()
+    let self_token = quote!(self);
+    let (enum_repr, nr_expr) = if variants.is_empty() {
+        (quote!(), quote!(match #self_token {}))
     } else {
-        quote!(#[repr(u8)])
+        (quote!(#[repr(u8)]), quote!(*#self_token as u8))
     };
 
     let interrupt_enum = quote! {
@@ -162,8 +163,8 @@ pub fn render(
 
         unsafe impl bare_metal::Nr for Interrupt {
             #[inline(always)]
-            fn nr(&self) -> u8 {
-                *self as u8
+            fn nr(&#self_token) -> u8 {
+                #nr_expr
             }
         }
     };

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -25,7 +25,6 @@ pub fn render(
     interrupts.sort_by_key(|i| i.value);
 
     let mut root = TokenStream::new();
-    let mut arms = vec![];
     let mut from_arms = vec![];
     let mut elements = vec![];
     let mut names = vec![];
@@ -58,11 +57,7 @@ pub fn render(
 
         variants.push(quote! {
             #[doc = #description]
-            #name_uc,
-        });
-
-        arms.push(quote! {
-            Interrupt::#name_uc => #value,
+            #name_uc = #value,
         });
 
         from_arms.push(quote! {
@@ -161,9 +156,7 @@ pub fn render(
         unsafe impl bare_metal::Nr for Interrupt {
             #[inline]
             fn nr(&self) -> u8 {
-                match *self {
-                    #(#arms)*
-                }
+                *self as u8
             }
         }
     };

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -148,7 +148,7 @@ pub fn render(
 
     let self_token = quote!(self);
     let (enum_repr, nr_expr) = if variants.is_empty() {
-        (quote!(), quote!(match #self_token {}))
+        (quote!(), quote!(match *#self_token {}))
     } else {
         (quote!(#[repr(u8)]), quote!(*#self_token as u8))
     };

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -146,10 +146,16 @@ pub fn render(
         Target::None => {}
     }
 
+    let enum_repr = if variants.is_empty() {
+        quote!()
+    } else {
+        quote!(#[repr(u8)])
+    };
+
     let interrupt_enum = quote! {
         ///Enumeration of all the interrupts
         #[derive(Copy, Clone, Debug)]
-        #[repr(u8)]
+        #enum_repr
         pub enum Interrupt {
             #(#variants)*
         }


### PR DESCRIPTION
Make the Interrupt enum descriminant match the interrupt nr directly. This allows simplifying Interrupt::nr from being a complicated match to a simple cast to an u8.

According to #370, this should lead to a code reduction of as much as 304 bytes.

Fixes #211
Fixes #370