### PR TITLE
Adjust CI to test MSRV and allow nightly to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,15 @@ env:
     - TARGET=x86_64-unknown-linux-gnu
 
 matrix:
+  allow_failures:
+    - rust: nightly
+
   include:
     # rustfmt
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=rustfmt
       rust: stable
 
-    # Nightly, for testing
+    # All generated code should be running on stable now
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Atmel
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Freescale
@@ -39,6 +42,11 @@ matrix:
 
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Toshiba
 
+    # MSRV
+    - env: TARGET=x86_64-unknown-linux-gnu VENDOR=Nordic
+      rust: 1.37.0
+
+    # Only works on nightly for now
     - env: TARGET=x86_64-unknown-linux-gnu VENDOR=OTHER
       rust: nightly
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,12 @@ This project is developed and maintained by the [Tools team][team].
 
 # [API](https://docs.rs/svd2rust)
 
+## Requirements
+
+The **generated code** is intended to compile on all stable versions of Rust greater or equal to **1.37.0**, as well as the latest beta and the latest nightly.
+
+If you encounter compilation errors on any stable version newer than 1.37.0, please open an issue.
+
 # Testing Locally
 
 `svd2rust-regress` is a helper program for regression testing changes against `svd2rust`. This tool can be used locally to check modifications of `svd2rust` locally before submitting a PR.


### PR DESCRIPTION
We're now documenting an (arbitrarily chosen) MSRV of 1.37.0 and testing
it in CI while also making nightly tests informational only.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>