### PR TITLE
Use standard wording for the MSRV note

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,8 +58,6 @@ matrix:
     # - env: TARGET=x86_64-unknown-linux-musl
 
     # OSX
-    - env: TARGET=i686-apple-darwin
-      os: osx
     - env: TARGET=x86_64-apple-darwin
       os: osx
 

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ This project is developed and maintained by the [Tools team][team].
 
 # [API](https://docs.rs/svd2rust)
 
-## Requirements
+## Minimum Supported Rust Version (MSRV)
 
-The **generated code** is intended to compile on all stable versions of Rust greater or equal to **1.37.0**, as well as the latest beta and the latest nightly.
+The **generated code** is guaranteed to compile on stable Rust 1.37.0 and up.
 
 If you encounter compilation errors on any stable version newer than 1.37.0, please open an issue.
 


### PR DESCRIPTION
Part of [wg/#445](https://github.com/rust-embedded/wg/issues/445).

svd2rust already has its MSRV documented and tested, but @adamgreig suggested updating it to use the standard wording. Since this is a special case in that the MSRV applies to the generated code, not svd2rust itself, the standard wording doesn't fully apply, so I changed it in a (hopefully) sensible way.

An open question is: Should we also document the MSRV of svd2rust itself? Looking at how the CI works, currently it's implicitly guaranteed to be the same version als the MSRV for the generated code, so we could just extend the note in the README to also include svd2rust itself.