### PR TITLE
Cluster name qualification

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -155,7 +155,7 @@ pub fn render(
         mod_items.extend(cluster_block(c, &defaults, p, all_peripherals, nightly)?);
     }
 
-    // Push all regsiter realted information into the peripheral module
+    // Push all register related information into the peripheral module
     for reg in registers {
         mod_items.extend(register::render(
             reg,


### PR DESCRIPTION
This contains two commits, the first is a simple typo fix. The second ensures that the complete-pathed type name is generated for clusters.