### PR TITLE
Add ESP32 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         rust: [stable]
 
         # All vendor files we want to test on stable
-        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba, Espressif]
+        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba]
 
         # The default target we're compiling on and for
         TARGET: [x86_64-unknown-linux-gnu]
@@ -33,6 +33,13 @@ jobs:
           - rust: nightly
             experimental: true
             VENDOR: OTHER
+            TARGET: x86_64-unknown-linux-gnu
+            TRAVIS_OS_NAME: linux
+
+            # Use nightly for architectures which don't support stable
+          - rust: nightly
+            experimental: true
+            VENDOR: Espressif
             TARGET: x86_64-unknown-linux-gnu
             TRAVIS_OS_NAME: linux
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         rust: [stable]
 
         # All vendor files we want to test on stable
-        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba]
+        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba, Espressif]
 
         # The default target we're compiling on and for
         TARGET: [x86_64-unknown-linux-gnu]

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -692,6 +692,17 @@ main() {
             # OK
             test_svd M061
         ;;
+
+        Espressif)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
+            echo '[dependencies.xtensa-lx6-rt]' >> $td/Cargo.toml
+            echo 'git = "https://github.com/esp-rs/xtensa-lx6-rt.git"' >> $td/Cargo.toml
+
+            test_svd_for_target esp32 https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
+        ;;
+
     esac
 
     rm -rf $td

--- a/ci/svd2rust-regress/README.md
+++ b/ci/svd2rust-regress/README.md
@@ -60,8 +60,7 @@ FLAGS:
 
 OPTIONS:
     -a, --architecture <arch>
-            Filter by architecture, case sensitive, may be combined with other filters Options are: "CortexM", "RiscV",
-            and "Msp430"
+            Filter by architecture, case sensitive, may be combined with other filters Options are: "CortexM", "RiscV", "Msp430" and "ESP32"
     -p, --svd2rust-path <bin_path>
             Path to an `svd2rust` binary, relative or absolute. Defaults to `target/release/svd2rust[.exe]` of this
             repository (which must be already built)

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -7,6 +7,7 @@ pub enum Architecture {
     CortexM,
     Msp430,
     RiscV,
+    ESP32,
 }
 
 #[derive(Debug)]
@@ -24,6 +25,7 @@ pub enum Manufacturer {
     Toshiba,
     SiFive,
     TexasInstruments,
+    Espressif,
 }
 
 #[derive(Debug)]
@@ -4223,6 +4225,16 @@ pub const TESTS: &[&TestCase] = &[
         mfgr: TexasInstruments,
         chip: "msp430g2553",
         svd_url: Some("https://github.com/pftbest/msp430g2553/raw/v0.1.3-svd/msp430g2553.svd"),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: ESP32,
+        mfgr: Espressif,
+        chip: "esp32",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd",
+        ),
         should_pass: true,
         run_when: Always,
     },

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -97,6 +97,11 @@ pub fn render(
                 extern crate riscv_rt;
             });
         }
+        Target::ESP32 => {
+            out.extend(quote! {
+                extern crate xtensa_lx6_rt;
+            });
+        }
         Target::None => {}
     }
 
@@ -226,6 +231,7 @@ pub fn render(
         Target::CortexM => Some(Ident::new("cortex_m", span)),
         Target::Msp430 => Some(Ident::new("msp430", span)),
         Target::RISCV => Some(Ident::new("riscv", span)),
+        Target::ESP32 => Some(Ident::new("xtensa_lx6_rt", span)),
         Target::None => None,
     }
     .map(|krate| {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@
 //!
 //! # Usage
 //!
-//! `svd2rust` supports Cortex-M, MSP430 and RISCV microcontrollers. The generated crate can be
-//! tailored for either architecture using the `--target` flag. The flag accepts "cortex-m",
-//! "msp430", "riscv" and "none" as values. "none" can be used to generate a crate that's
+//! `svd2rust` supports Cortex-M, MSP430, RISCV and ESP32 microcontrollers. The generated crate can
+//! be tailored for either architecture using the `--target` flag. The flag accepts "cortex-m",
+//! "msp430", "riscv", "esp32" and "none" as values. "none" can be used to generate a crate that's
 //! architecture agnostic and that should work for architectures that `svd2rust` doesn't currently
 //! know about like the Cortex-A architecture.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn run() -> Result<()> {
     file.write_all(data.as_ref())
         .expect("Could not write code to lib.rs");
 
-    if target == Target::CortexM || target == Target::Msp430 {
+    if target == Target::CortexM || target == Target::Msp430 || target == Target::ESP32 {
         writeln!(File::create("device.x")?, "{}", device_x)?;
         writeln!(File::create("build.rs")?, "{}", build_rs())?;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,6 +18,7 @@ pub enum Target {
     CortexM,
     Msp430,
     RISCV,
+    ESP32,
     None,
 }
 
@@ -27,6 +28,7 @@ impl Target {
             "cortex-m" => Target::CortexM,
             "msp430" => Target::Msp430,
             "riscv" => Target::RISCV,
+            "esp32" => Target::ESP32,
             "none" => Target::None,
             _ => bail!("unknown target {}", s),
         })


### PR DESCRIPTION
Adding support for ESP32 as used in new pull requests on https://github.com/esp-rs.

ESP32 has 2 level interrupt handling. First level in the cores. Second level in the periphery/software.