### PR TITLE
Rename ESP32 to XTensaLX6 and split crate into rt and base

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -703,7 +703,7 @@ main() {
             echo '[dependencies.xtensa-lx6-rt]' >> $td/Cargo.toml
             echo 'git = "https://github.com/esp-rs/xtensa-lx6-rt.git"' >> $td/Cargo.toml
 
-            test_svd_for_target esp32 https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
+            test_svd_for_target xtensalx6 https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
         ;;
 
     esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -698,10 +698,10 @@ main() {
             echo 'version = "0.2.0"' >> $td/Cargo.toml
 
             echo '[dependencies.xtensa-lx6]' >> $td/Cargo.toml
-            echo 'git = "https://github.com/esp-rs/xtensa-lx6.git"' >> $td/Cargo.toml
+            echo 'version = "0.1.0"' >> $td/Cargo.toml
 
             echo '[dependencies.xtensa-lx6-rt]' >> $td/Cargo.toml
-            echo 'git = "https://github.com/esp-rs/xtensa-lx6-rt.git"' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
 
             test_svd_for_target xtensalx6 https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
         ;;

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -697,6 +697,9 @@ main() {
             echo '[dependencies.bare-metal]' >> $td/Cargo.toml
             echo 'version = "0.2.0"' >> $td/Cargo.toml
 
+            echo '[dependencies.xtensa-lx6]' >> $td/Cargo.toml
+            echo 'git = "https://github.com/esp-rs/xtensa-lx6.git"' >> $td/Cargo.toml
+
             echo '[dependencies.xtensa-lx6-rt]' >> $td/Cargo.toml
             echo 'git = "https://github.com/esp-rs/xtensa-lx6-rt.git"' >> $td/Cargo.toml
 

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -10,8 +10,7 @@ static CRATES_ALL: &[&str] = &["bare-metal = \"0.2.0\"", "vcell = \"0.1.0\""];
 static CRATES_MSP430: &[&str] = &["msp430 = \"0.1.0\""];
 static CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.5.0\"", "cortex-m-rt = \"0.5.0\""];
 static CRATES_RISCV: &[&str] = &["riscv = \"0.4.0\"", "riscv-rt = \"0.4.0\""];
-static CRATES_ESP32: &[&str] =
-    &["xtensa-lx6-rt = {git=\"https://github.com/esp-rs/xtensa-lx6-rt\"}"];
+static CRATES_XTENSALX6: &[&str] = &["xtensa-lx6-rt = \"0.2.0\"", "xtensa-lx6 = \"0.1.0\""];
 static PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];
 static FEATURES_ALL: &[&str] = &["[features]"];
 static FEATURES_CORTEX_M: &[&str] =
@@ -135,7 +134,7 @@ pub fn test(
             CortexM => CRATES_CORTEX_M.iter(),
             RiscV => CRATES_RISCV.iter(),
             Msp430 => CRATES_MSP430.iter(),
-            ESP32 => CRATES_ESP32.iter(),
+            XtensaLX6 => CRATES_XTENSALX6.iter(),
         })
         .chain(PROFILE_ALL.iter())
         .chain(FEATURES_ALL.iter())
@@ -168,7 +167,7 @@ pub fn test(
         CortexM => "cortex-m",
         Msp430 => "msp430",
         RiscV => "riscv",
-        ESP32 => "esp32",
+        XtensaLX6 => "xtensalx6",
     };
     let mut svd2rust_bin = Command::new(bin_path);
     if nightly {
@@ -185,14 +184,14 @@ pub fn test(
         true,
         "svd2rust",
         Some(&lib_rs_file)
-            .filter(|_| (t.arch != CortexM) && (t.arch != Msp430) && (t.arch != ESP32)),
+            .filter(|_| (t.arch != CortexM) && (t.arch != Msp430) && (t.arch != XtensaLX6)),
         Some(&svd2rust_err_file),
         &[],
     )?;
     process_stderr_paths.push(svd2rust_err_file);
 
     match t.arch {
-        CortexM | Msp430 | ESP32 => {
+        CortexM | Msp430 | XtensaLX6 => {
             // TODO: Give error the path to stderr
             fs::rename(path_helper_base(&chip_dir, &["lib.rs"]), &lib_rs_file)
                 .chain_err(|| "While moving lib.rs file")?

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -7,7 +7,7 @@ pub enum Architecture {
     CortexM,
     Msp430,
     RiscV,
-    ESP32,
+    XtensaLX6,
 }
 
 #[derive(Debug)]
@@ -4229,7 +4229,7 @@ pub const TESTS: &[&TestCase] = &[
         run_when: Always,
     },
     &TestCase {
-        arch: ESP32,
+        arch: XtensaLX6,
         mfgr: Espressif,
         chip: "esp32",
         svd_url: Some(

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -4232,7 +4232,9 @@ pub const TESTS: &[&TestCase] = &[
         arch: XtensaLX6,
         mfgr: Espressif,
         chip: "esp32",
-        svd_url: Some("https://raw.githubusercontent.com/esp-rs/esp32/master/svd/esp32.svd"),
+        svd_url: Some(
+            "https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd",
+        ),
         should_pass: true,
         run_when: Always,
     },

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -4232,9 +4232,7 @@ pub const TESTS: &[&TestCase] = &[
         arch: XtensaLX6,
         mfgr: Espressif,
         chip: "esp32",
-        svd_url: Some(
-            "https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd",
-        ),
+        svd_url: Some("https://raw.githubusercontent.com/esp-rs/esp32/master/svd/esp32.svd"),
         should_pass: true,
         run_when: Always,
     },

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -97,8 +97,10 @@ pub fn render(
                 extern crate riscv_rt;
             });
         }
-        Target::ESP32 => {
+        Target::XtensaLX6 => {
             out.extend(quote! {
+                extern crate xtensa_lx6;
+                #[cfg(feature = "rt")]
                 extern crate xtensa_lx6_rt;
             });
         }
@@ -231,7 +233,7 @@ pub fn render(
         Target::CortexM => Some(Ident::new("cortex_m", span)),
         Target::Msp430 => Some(Ident::new("msp430", span)),
         Target::RISCV => Some(Ident::new("riscv", span)),
-        Target::ESP32 => Some(Ident::new("xtensa_lx6_rt", span)),
+        Target::XtensaLX6 => Some(Ident::new("xtensa_lx6", span)),
         Target::None => None,
     }
     .map(|krate| {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -125,7 +125,7 @@ pub fn render(
             });
         }
         Target::RISCV => {}
-        Target::ESP32 => {
+        Target::XtensaLX6 => {
             for name in &names {
                 writeln!(device_x, "PROVIDE({} = DefaultHandler);", name)?;
             }
@@ -202,7 +202,7 @@ pub fn render(
             _ => "C",
         };
 
-        if target != Target::CortexM && target != Target::Msp430 && target != Target::ESP32 {
+        if target != Target::CortexM && target != Target::Msp430 && target != Target::XtensaLX6 {
             mod_items.extend(quote! {
                 #[cfg(feature = "rt")]
                 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,9 +18,9 @@
 //!
 //! # Usage
 //!
-//! `svd2rust` supports Cortex-M, MSP430, RISCV and ESP32 microcontrollers. The generated crate can
+//! `svd2rust` supports Cortex-M, MSP430, RISCV and Xtensa LX6 microcontrollers. The generated crate can
 //! be tailored for either architecture using the `--target` flag. The flag accepts "cortex-m",
-//! "msp430", "riscv", "esp32" and "none" as values. "none" can be used to generate a crate that's
+//! "msp430", "riscv", "xtensalx6" and "none" as values. "none" can be used to generate a crate that's
 //! architecture agnostic and that should work for architectures that `svd2rust` doesn't currently
 //! know about like the Cortex-A architecture.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -103,7 +103,7 @@ fn run() -> Result<()> {
     file.write_all(data.as_ref())
         .expect("Could not write code to lib.rs");
 
-    if target == Target::CortexM || target == Target::Msp430 || target == Target::ESP32 {
+    if target == Target::CortexM || target == Target::Msp430 || target == Target::XtensaLX6 {
         writeln!(File::create("device.x")?, "{}", device_x)?;
         writeln!(File::create("build.rs")?, "{}", build_rs())?;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub enum Target {
     CortexM,
     Msp430,
     RISCV,
-    ESP32,
+    XtensaLX6,
     None,
 }
 
@@ -28,7 +28,7 @@ impl Target {
             "cortex-m" => Target::CortexM,
             "msp430" => Target::Msp430,
             "riscv" => Target::RISCV,
-            "esp32" => Target::ESP32,
+            "xtensalx6" => Target::XtensaLX6,
             "none" => Target::None,
             _ => bail!("unknown target {}", s),
         })


### PR DESCRIPTION
This PR renames ESP32 (SOC name) to XtensaLX6 (CPU name) to align to convention of other platforms.

It also adds seperate xtensa-lx6-rt and xtensa-lx6 support (instead of just xtensa-lx6-rt).