### PR TITLE
Get rid of a boatload of unnecessary braces warnings

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -499,15 +499,25 @@ pub fn fields(
                     }
                 }
 
-                proxy_items.extend(quote! {
-                    ///Writes `variant` to the field
-                    #inline
-                    pub fn variant(self, variant: #pc_w) -> &'a mut W {
-                        #unsafety {
-                            self.#bits(variant.into())
+                if unsafety.is_some() {
+                    proxy_items.extend(quote! {
+                        ///Writes `variant` to the field
+                        #inline
+                        pub fn variant(self, variant: #pc_w) -> &'a mut W {
+                            unsafe {
+                                self.#bits(variant.into())
+                            }
                         }
-                    }
-                });
+                    });
+                } else {
+                    proxy_items.extend(quote! {
+                        ///Writes `variant` to the field
+                        #inline
+                        pub fn variant(self, variant: #pc_w) -> &'a mut W {
+                                self.#bits(variant.into())
+                        }
+                    });
+                }
 
                 for v in &variants {
                     let pc = &v.pc;


### PR DESCRIPTION
```
warning: unnecessary braces around block return value
     --> src/lib.rs:22188:62
      |
22188 | pub fn variant ( self , variant : HSEBYP_A ) -> & 'a mut W { { self . bit ( variant . into ( ) ) } } # [ doc = "HSE crystal oscillator not bypassed" ]
      |                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: remove these braces
```

Signed-off-by: Daniel Egger <daniel@eggers-club.de>