### PR TITLE
Remove bare-metal dependency from generated crates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   use the `msp430_rt::interrupt` attribute macro and `device.x` for interrupt
   support. The `INTERRUPT` array has been renamed `__INTERRUPT`.
 
+- [breaking-change] Remove use of `bare_metal::Nr` trait and consecutively the
+  use of `bare-metal`.
+
 ## [v0.17.0] - 2019-12-31
 
 ### Fixed

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -76,9 +76,6 @@ main() {
 
     case $VENDOR in
         Atmel)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD missing resetValue
             # test_svd AT91SAM9CN11
             # test_svd AT91SAM9CN12
@@ -162,9 +159,6 @@ main() {
         ;;
 
         Freescale)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD bad enumeratedValue value
             # test_svd MKV56F20
             # test_svd MKV56F22
@@ -313,9 +307,6 @@ main() {
         ;;
 
         Fujitsu)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd MB9AF10xN
             test_svd MB9AF10xR
@@ -420,9 +411,6 @@ main() {
         ;;
 
         Holtek)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd ht32f125x
             test_svd ht32f175x
@@ -430,9 +418,6 @@ main() {
         ;;
 
         Nordic)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD two enumeratedValues have the same value
             # test_svd nrf52
 
@@ -441,18 +426,12 @@ main() {
         ;;
 
         Nuvoton)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd M051_Series
             test_svd NUC100_Series
         ;;
 
         NXP)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             test_svd MK22F25612
             test_svd MKW41Z4
 
@@ -493,9 +472,6 @@ main() {
 
         # test other targets (architectures)
         OTHER)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.1.0"' >> $td/Cargo.toml
-
             echo '[dependencies.msp430]' >> $td/Cargo.toml
             echo 'version = "0.2.2"' >> $td/Cargo.toml
 
@@ -505,9 +481,6 @@ main() {
 
         # Community-provided RISC-V SVDs
         RISC-V)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             echo '[dependencies.riscv]' >> $td/Cargo.toml
             echo 'version = "0.5.0"' >> $td/Cargo.toml
 
@@ -520,9 +493,6 @@ main() {
         ;;
 
         SiliconLabs)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # #99 regression tests
             test_svd SIM3C1x4_SVD
             test_svd SIM3C1x6_SVD
@@ -539,9 +509,6 @@ main() {
         ;;
 
         Spansion)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd MB9AF12xK
             test_svd MB9AF12xL
@@ -637,9 +604,6 @@ main() {
         ;;
 
         STMicro)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd STM32F030
             test_svd STM32F031x
@@ -679,9 +643,6 @@ main() {
         ;;
 
         Toshiba)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD resetValue is bigger than the register size
             # test_svd M365
             # test_svd M367
@@ -694,9 +655,6 @@ main() {
         ;;
 
         Espressif)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             echo '[dependencies.xtensa-lx6]' >> $td/Cargo.toml
             echo 'version = "0.1.0"' >> $td/Cargo.toml
 

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -6,7 +6,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
-static CRATES_ALL: &[&str] = &["bare-metal = \"0.2.0\"", "vcell = \"0.1.0\""];
+static CRATES_ALL: &[&str] = &["vcell = \"0.1.0\""];
 static CRATES_MSP430: &[&str] = &["msp430 = \"0.1.0\""];
 static CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.5.0\"", "cortex-m-rt = \"0.5.0\""];
 static CRATES_RISCV: &[&str] = &["riscv = \"0.4.0\"", "riscv-rt = \"0.4.0\""];
@@ -14,7 +14,7 @@ static CRATES_XTENSALX6: &[&str] = &["xtensa-lx6-rt = \"0.2.0\"", "xtensa-lx6 = 
 static PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];
 static FEATURES_ALL: &[&str] = &["[features]"];
 static FEATURES_CORTEX_M: &[&str] =
-    &["const-fn = [\"bare-metal/const-fn\", \"cortex-m/const-fn\"]"];
+    &["const-fn = [\"cortex-m/const-fn\"]"];
 static FEATURES_EMPTY: &[&str] = &[];
 
 fn path_helper(input: &[&str]) -> PathBuf {

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -108,7 +108,6 @@ pub fn render(
     }
 
     out.extend(quote! {
-        extern crate bare_metal;
         extern crate vcell;
 
         use core::ops::Deref;

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -152,11 +152,10 @@ pub fn render(
         Target::None => {}
     }
 
-    let self_token = quote!(self);
-    let (enum_repr, nr_expr) = if variants.is_empty() {
-        (quote!(), quote!(match *#self_token {}))
+    let enum_repr = if variants.is_empty() {
+        quote!()
     } else {
-        (quote!(#[repr(u8)]), quote!(*#self_token as u8))
+        quote!(#[repr(u8)])
     };
 
     let interrupt_enum = quote! {
@@ -165,13 +164,6 @@ pub fn render(
         #enum_repr
         pub enum Interrupt {
             #variants
-        }
-
-        unsafe impl bare_metal::Nr for Interrupt {
-            #[inline(always)]
-            fn nr(&#self_token) -> u8 {
-                #nr_expr
-            }
         }
     };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,13 +53,12 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` >=v0.6.5 and `vcell` v0.1.x. Furthermore
+//! `cortex-m` v0.5.x, `cortex-m-rt` >=v0.6.5 and `vcell` v0.1.x. Furthermore
 //! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
-//! bare-metal = "0.2.0"
 //! cortex-m = "0.5.8"
 //! vcell = "0.1.0"
 //!
@@ -106,13 +105,12 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `msp430` v0.2.x, `msp430-rt` v0.2.x and `vcell` v0.1.x. Furthermore
+//! `msp430` v0.2.x, `msp430-rt` v0.2.x and `vcell` v0.1.x. Furthermore
 //! the "device" feature of `msp430-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
-//! bare-metal = "0.2.0"
 //! msp430 = "0.2.0"
 //! vcell = "0.1.0"
 //!
@@ -131,7 +129,6 @@
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
 //!
-//! - [`bare-metal`](https://crates.io/crates/bare-metal) v0.2.x
 //! - [`vcell`](https://crates.io/crates/vcell) v0.1.x
 //! - [`riscv`](https://crates.io/crates/riscv) v0.4.x if target = riscv.
 //! - [`riscv-rt`](https://crates.io/crates/riscv-rt) v0.4.x if target = riscv.
@@ -141,7 +138,6 @@
 //!
 //! ``` toml
 //! [dependencies]
-//! bare-metal = "0.2.0"
 //! riscv = "0.4.0"
 //! vcell = "0.1.0"
 //!


### PR DESCRIPTION
The only dependency on `bare-metal` was the implementation of the `Nr`
trait which has been removed from version 1.0.0
(rust-embedded/bare-metal#32).

Closes #453

Signed-off-by: Daniel Egger <daniel@eggers-club.de>