### PR TITLE
Use and generate code for Edition 2018 only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   use the `msp430_rt::interrupt` attribute macro and `device.x` for interrupt
   support. The `INTERRUPT` array has been renamed `__INTERRUPT`.
 
+- Don't generate pre Edition 2018 `extern crate` statements anymore
+
 ## [v0.17.0] - 2019-12-31
 
 ### Fixed

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -1,6 +1,6 @@
 use crate::svd::Device;
 use proc_macro2::{Ident, Span, TokenStream};
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use std::fs::File;
 use std::io::Write;
 
@@ -75,42 +75,7 @@ pub fn render(
         #![no_std]
     });
 
-    match target {
-        Target::CortexM => {
-            out.extend(quote! {
-                extern crate cortex_m;
-                #[cfg(feature = "rt")]
-                extern crate cortex_m_rt;
-            });
-        }
-        Target::Msp430 => {
-            out.extend(quote! {
-                extern crate msp430;
-                #[cfg(feature = "rt")]
-                extern crate msp430_rt;
-            });
-        }
-        Target::RISCV => {
-            out.extend(quote! {
-                extern crate riscv;
-                #[cfg(feature = "rt")]
-                extern crate riscv_rt;
-            });
-        }
-        Target::XtensaLX6 => {
-            out.extend(quote! {
-                extern crate xtensa_lx6;
-                #[cfg(feature = "rt")]
-                extern crate xtensa_lx6_rt;
-            });
-        }
-        Target::None => {}
-    }
-
     out.extend(quote! {
-        extern crate bare_metal;
-        extern crate vcell;
-
         use core::ops::Deref;
         use core::marker::PhantomData;
     });

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -4,6 +4,7 @@ use std::fmt::Write;
 use crate::svd::Peripheral;
 use cast::u64;
 use proc_macro2::{Ident, Span, TokenStream};
+use quote::quote;
 
 use crate::util::{self, ToSanitizedUpperCase};
 use crate::Target;

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -6,7 +6,7 @@ use crate::svd::{Cluster, ClusterInfo, Peripheral, Register, RegisterCluster, Re
 use log::warn;
 use proc_macro2::TokenStream;
 use proc_macro2::{Ident, Punct, Spacing, Span};
-use quote::ToTokens;
+use quote::{quote, ToTokens};
 use svd_parser::derive_from::DeriveFrom;
 use syn::{parse_str, Token};
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -1,4 +1,3 @@
-use crate::quote::ToTokens;
 use crate::svd::{
     Access, BitRange, EnumeratedValues, Field, Peripheral, Register, RegisterCluster,
     RegisterProperties, Usage, WriteConstraint,
@@ -6,6 +5,7 @@ use crate::svd::{
 use cast::u64;
 use log::warn;
 use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
+use quote::{quote, ToTokens};
 
 use crate::util::{self, ToSanitizedSnakeCase, ToSanitizedUpperCase, U32Ext};
 use anyhow::{anyhow, Result};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -451,9 +451,6 @@
 //! used with the `cortex-m` crate `NVIC` API.
 //!
 //! ```ignore
-//! extern crate cortex_m;
-//! extern crate stm32f30x;
-//!
 //! use cortex_m::interrupt;
 //! use cortex_m::peripheral::Peripherals;
 //! use stm32f30x::Interrupt;
@@ -481,8 +478,7 @@
 //! compiler. Currently there are no nightly features the flag is only kept for compatibility with prior versions.
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate quote;
+use quote::quote;
 use svd_parser as svd;
 
 mod generate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,6 @@
 #![recursion_limit = "128"]
 
-#[macro_use]
-extern crate log;
-#[macro_use]
-extern crate quote;
+use log::error;
 use svd_parser as svd;
 
 mod generate;

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 use std::borrow::Cow;
 
-use crate::quote::ToTokens;
 use crate::svd::{Access, Cluster, Register, RegisterCluster};
 use inflections::Inflect;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
+use quote::{quote, ToTokens};
 
 use anyhow::{anyhow, bail, Result};
 


### PR DESCRIPTION
No need to maintain extern crate imports anymore

Signed-off-by: Daniel Egger <daniel@eggers-club.de>