### PR TITLE
Remove `PhantomData<*const ()>` from peripherals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Don't generate pre Edition 2018 `extern crate` statements anymore
 
+- Remove `PhantomData` marker from peripherals
+
 ## [v0.17.0] - 2019-12-31
 
 ### Fixed

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -77,7 +77,6 @@ pub fn render(
 
     out.extend(quote! {
         use core::ops::Deref;
-        use core::marker::PhantomData;
     });
 
     // Retaining the previous assumption
@@ -190,7 +189,7 @@ pub fn render(
             #[doc = #p]
             pub #id: #id,
         });
-        exprs.extend(quote!(#id: #id { _marker: PhantomData },));
+        exprs.extend(quote!(#id: #id {}, ));
     }
 
     let span = Span::call_site();

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -54,7 +54,7 @@ pub fn render(
     // Insert the peripheral structure
     out.extend(quote! {
         #[doc = #description]
-        pub struct #name_pc { _marker: PhantomData<*const ()> }
+        pub struct #name_pc { }
 
         unsafe impl Send for #name_pc {}
 


### PR DESCRIPTION
Not sure which purpose they're supposed to serve but the do seem kind of
pointless.

Signed-off-by: Daniel Egger <daniel@eggers-club.de>