### PR TITLE
Rework `Interrupt` enum for MSP430

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   use the `msp430_rt::interrupt` attribute macro and `device.x` for interrupt
   support. The `INTERRUPT` array has been renamed `__INTERRUPT`.
 
+- Documented the nature of the `Interrupt` enum on MSP430 and consequently
+  removed all use of `bare-metal` from that architecture
+
 - Don't generate pre Edition 2018 `extern crate` statements anymore
 
 ## [v0.17.0] - 2019-12-31

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -493,9 +493,6 @@ main() {
 
         # test other targets (architectures)
         OTHER)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.1.0"' >> $td/Cargo.toml
-
             echo '[dependencies.msp430]' >> $td/Cargo.toml
             echo 'version = "0.2.2"' >> $td/Cargo.toml
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,13 +106,12 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `msp430` v0.2.x, `msp430-rt` v0.2.x and `vcell` v0.1.x. Furthermore
+//! `msp430` v0.2.x, `msp430-rt` v0.2.x and `vcell` v0.1.x. Furthermore
 //! the "device" feature of `msp430-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
-//! bare-metal = "0.2.0"
 //! msp430 = "0.2.0"
 //! vcell = "0.1.0"
 //!


### PR DESCRIPTION
This also removes the `bare-metal` dependency from PACs created for
MSP430, as requested in
https://github.com/rust-embedded/svd2rust/pull/455#issuecomment-665214017

Signed-off-by: Daniel Egger <daniel@eggers-club.de>