### PR TITLE
Register trait improvements

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -203,24 +203,6 @@ where
     }
 }
 
-impl<REG: Register<Ux=bool>> R<REG> {
-    /// Value of the field as raw bits.
-    #[inline(always)]
-    pub fn bit(&self) -> bool {
-        self.bits
-    }
-    /// Returns `true` if the bit is clear (0).
-    #[inline(always)]
-    pub fn bit_is_clear(&self) -> bool {
-        !self.bit()
-    }
-    /// Returns `true` if the bit is set (1).
-    #[inline(always)]
-    pub fn bit_is_set(&self) -> bool {
-        self.bit()
-    }
-}
-
 /// Register writer.
 ///
 /// Used as an argument to the closures in the `write` and `modify` methods of the register.

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -35,10 +35,7 @@ pub struct Reg<REG: Register> {
 
 unsafe impl<REG: Register> Send for Reg<REG> where REG::Ux: Send {}
 
-impl<REG: Register> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Register> Reg<REG> {
     /// Returns the underlying memory address of register.
     ///
     /// ```ignore
@@ -50,10 +47,7 @@ where
     }
 }
 
-impl<REG: Readable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Readable> Reg<REG> {
     /// Reads the contents of a `Readable` register.
     ///
     /// You can read the raw contents of a register by using `bits`:
@@ -75,10 +69,7 @@ where
     }
 }
 
-impl<REG: Resettable + Writable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Resettable + Writable> Reg<REG> {
     /// Writes the reset value to `Writable` register.
     ///
     /// Resets the register to its initial state.
@@ -119,7 +110,7 @@ where
 
 impl<REG: Writable> Reg<REG>
 where
-    REG::Ux: Copy + Default,
+    REG::Ux: Default,
 {
     /// Writes 0 to a `Writable` register.
     ///
@@ -139,10 +130,7 @@ where
     }
 }
 
-impl<REG: Readable + Writable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Readable + Writable> Reg<REG> {
     /// Modifies the contents of the register by reading and then writing it.
     ///
     /// E.g. to do a read-modify-write sequence to change parts of a register:
@@ -191,10 +179,7 @@ pub struct R<REG: Register> {
     _reg: marker::PhantomData<REG>,
 }
 
-impl<REG: Register> R<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Register> R<REG> {
     /// Reads raw bits from register.
     #[inline(always)]
     pub fn bits(&self) -> REG::Ux {

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -9,20 +9,20 @@ pub trait Register {
 /// Trait implemented by readable registers to enable the `read` method.
 ///
 /// Registers marked with `Writable` can be also `modify`'ed.
-pub trait ReadableRegister: Register {}
+pub trait Readable: Register {}
 
 /// Trait implemented by writeable registers.
 ///
 /// This enables the  `write`, `write_with_zero` and `reset` methods.
 ///
 /// Registers marked with `Readable` can be also `modify`'ed.
-pub trait WritableRegister: Register {}
+pub trait Writable: Register {}
 
 /// Reset value of the register.
 ///
 /// This value is the initial value for the `write` method. It can also be directly written to the
 /// register by using the `reset` method.
-pub trait ResettableRegister: Register {
+pub trait Resettable: Register {
     /// Reset value of the register.
     fn reset_value() -> Self::Ux;
 }
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<REG: ReadableRegister> Reg<REG>
+impl<REG: Readable> Reg<REG>
 where
     REG::Ux: Copy,
 {
@@ -75,7 +75,7 @@ where
     }
 }
 
-impl<REG: ResettableRegister + WritableRegister> Reg<REG>
+impl<REG: Resettable + Writable> Reg<REG>
 where
     REG::Ux: Copy,
 {
@@ -117,7 +117,7 @@ where
     }
 }
 
-impl<REG: WritableRegister> Reg<REG>
+impl<REG: Writable> Reg<REG>
 where
     REG::Ux: Copy + Default,
 {
@@ -139,7 +139,7 @@ where
     }
 }
 
-impl<REG: ReadableRegister + WritableRegister> Reg<REG>
+impl<REG: Readable + Writable> Reg<REG>
 where
     REG::Ux: Copy,
 {

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -20,6 +20,7 @@ pub trait Readable: Register {
 ///
 /// Registers marked with `Readable` can be also `modify`'ed.
 pub trait Writable: Register {
+    /// Writer type argument to `write`, et al.
     type Writer: core::convert::From<W<Self>> + core::ops::Deref<Target = W<Self>>;
 }
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -917,7 +917,7 @@ fn name_to_ty_cow<'a>(name: &'a String, ns: Option<&str>) -> Cow<'a, str> {
 
 fn name_to_ty_str_wrapped(name: &String, ns: Option<&str>) -> String {
     let ident = name_to_ty_cow(name, ns);
-    format!("crate::Reg<_{}>", ident)
+    format!("crate::Reg<{}>", ident)
 }
 
 fn name_to_ty(name: &String, ns: Option<&str>) -> Result<syn::Type, syn::Error> {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -70,7 +70,7 @@ pub fn render(
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::ResettableRegister for super::#name_pc {
+                impl crate::Resettable for super::#name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -165,7 +165,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::ReadableRegister for #name_pc {}
+            impl crate::Readable for #name_pc {}
         });
     }
     if can_write {
@@ -175,7 +175,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::WritableRegister for #name_pc {}
+            impl crate::Writable for #name_pc {}
         });
     }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -80,13 +80,6 @@ pub fn render(
             #[doc = #desc]
             pub struct W(crate::W<#name_pc>);
 
-            impl W {
-                pub unsafe fn bits(&mut self, bits: #rty) -> &mut Self {
-                    self.0.bits(bits);
-                    self
-                }
-            }
-
             impl core::ops::Deref for W {
                 type Target = crate::W<#name_pc>;
 
@@ -171,6 +164,14 @@ pub fn render(
         });
 
         mod_items.extend(w_impl_items);
+
+        mod_items.extend(quote! {
+                #[doc = "Writes raw bits to the register."]
+                pub unsafe fn bits(&mut self, bits: #rty) -> &mut Self {
+                    self.0.bits(bits);
+                    self
+                }
+        });
 
         close.to_tokens(&mut mod_items);
     }

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -21,7 +21,6 @@ pub fn render(
     let name = util::name_of(register);
     let span = Span::call_site();
     let name_pc = Ident::new(&name.to_sanitized_upper_case(), span);
-    let u_name_pc = Ident::new(&format!("_{}", &name.to_sanitized_upper_case()), span);
     let name_sc = Ident::new(&name.to_sanitized_snake_case(), span);
     let rsize = register
         .size
@@ -55,7 +54,7 @@ pub fn render(
         let desc = format!("Reader of register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type R = crate::R<super::#u_name_pc>;
+            pub type R = crate::R<super::#name_pc>;
         });
         methods.push("read");
     }
@@ -65,13 +64,13 @@ pub fn render(
         let desc = format!("Writer for register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type W = crate::W<super::#u_name_pc>;
+            pub type W = crate::W<super::#name_pc>;
         });
         if let Some(rv) = res_val.map(util::hex) {
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::ResettableRegister for super::#u_name_pc {
+                impl crate::ResettableRegister for super::#name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -152,13 +151,9 @@ pub fn render(
     }
     out.extend(quote! {
         #[doc = #doc]
-        pub type #name_pc = crate::Reg<#u_name_pc>;
+        pub struct #name_pc;
 
-        #[allow(missing_docs)]
-        #[doc(hidden)]
-        pub struct #u_name_pc;
-
-        impl crate::Register for #u_name_pc {
+        impl crate::Register for #name_pc {
             type Ux = #rty;
         }
     });
@@ -170,7 +165,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::ReadableRegister for #u_name_pc {}
+            impl crate::ReadableRegister for #name_pc {}
         });
     }
     if can_write {
@@ -180,7 +175,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::WritableRegister for #u_name_pc {}
+            impl crate::WritableRegister for #name_pc {}
         });
     }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -218,7 +218,12 @@ pub fn render(
         });
     }
 
+    let alias_doc = format!(
+        "{} register accessor: an alias for `Reg<{}::{}>`",
+        name, name_sc, name_pc
+    );
     out.extend(quote! {
+        #[doc = #alias_doc]
         pub type #name_pc = crate::Reg<#name_sc::#name_pc>;
     });
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -54,10 +54,10 @@ pub fn render(
         let desc = format!("Reader of register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub struct R(crate::R<super::#name_pc>);
+            pub struct R(crate::R<#name_pc>);
 
             impl core::ops::Deref for R {
-                type Target = crate::R<super::#name_pc>;
+                type Target = crate::R<#name_pc>;
 
                 fn deref(&self) -> &Self::Target {
                     &self.0
@@ -78,7 +78,7 @@ pub fn render(
         let desc = format!("Writer for register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub struct W(crate::W<super::#name_pc>);
+            pub struct W(crate::W<#name_pc>);
 
             impl W {
                 pub unsafe fn bits(&mut self, bits: #rty) -> &mut Self {
@@ -101,8 +101,8 @@ pub fn render(
                 }
             }
 
-            impl core::convert::From<crate::W<super::#name_pc>> for W {
-                fn from(writer: crate::W<super::#name_pc>) -> Self {
+            impl core::convert::From<crate::W<#name_pc>> for W {
+                fn from(writer: crate::W<#name_pc>) -> Self {
                     W(writer)
                 }
             }
@@ -111,7 +111,7 @@ pub fn render(
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::Resettable for super::#name_pc {
+                impl crate::Resettable for #name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -185,12 +185,12 @@ pub fn render(
 
     if name_sc != "cfg" {
         doc += format!(
-            "\n\nFor information about available fields see [{0}]({0}) module",
+            "\n\nFor information about available fields see [{0}](index.html) module",
             &name_sc
         )
         .as_str();
     }
-    out.extend(quote! {
+    mod_items.extend(quote! {
         #[doc = #doc]
         pub struct #name_pc;
 
@@ -200,11 +200,8 @@ pub fn render(
     });
 
     if can_read {
-        let doc = format!(
-            "`read()` method returns [{0}::R]({0}::R) reader structure",
-            &name_sc
-        );
-        out.extend(quote! {
+        let doc = "`read()` method returns [R](R) reader structure";
+        mod_items.extend(quote! {
             #[doc = #doc]
             impl crate::Readable for #name_pc {
                 type Reader = R;
@@ -212,17 +209,18 @@ pub fn render(
         });
     }
     if can_write {
-        let doc = format!(
-            "`write(|w| ..)` method takes [{0}::W]({0}::W) writer structure",
-            &name_sc
-        );
-        out.extend(quote! {
+        let doc = "`write(|w| ..)` method takes [W](W) writer structure";
+        mod_items.extend(quote! {
             #[doc = #doc]
             impl crate::Writable for #name_pc {
-                type Writer = #name_sc::W;
+                type Writer = W;
             }
         });
     }
+
+    out.extend(quote! {
+        pub type #name_pc = crate::Reg<#name_sc::#name_pc>;
+    });
 
     out.extend(quote! {
         #[doc = #description]

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -71,7 +71,7 @@ pub fn render(
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::ResetValue for super::#name_pc {
+                impl crate::ResettableRegister for super::#u_name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -152,11 +152,15 @@ pub fn render(
     }
     out.extend(quote! {
         #[doc = #doc]
-        pub type #name_pc = crate::Reg<#rty, #u_name_pc>;
+        pub type #name_pc = crate::Reg<#u_name_pc>;
 
         #[allow(missing_docs)]
         #[doc(hidden)]
         pub struct #u_name_pc;
+
+        impl crate::Register for #u_name_pc {
+            type Ux = #rty;
+        }
     });
 
     if can_read {
@@ -166,7 +170,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::Readable for #name_pc {}
+            impl crate::ReadableRegister for #u_name_pc {}
         });
     }
     if can_write {
@@ -176,7 +180,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::Writable for #name_pc {}
+            impl crate::WritableRegister for #u_name_pc {}
         });
     }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -55,7 +55,7 @@ pub fn render(
         let desc = format!("Reader of register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type R = crate::R<#rty, super::#name_pc>;
+            pub type R = crate::R<super::#u_name_pc>;
         });
         methods.push("read");
     }
@@ -65,7 +65,7 @@ pub fn render(
         let desc = format!("Writer for register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type W = crate::W<#rty, super::#name_pc>;
+            pub type W = crate::W<super::#u_name_pc>;
         });
         if let Some(rv) = res_val.map(util::hex) {
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
@@ -381,7 +381,7 @@ pub fn fields(
 
                     mod_items.extend(quote! {
                         #[doc = #readerdoc]
-                        pub type #name_pc_r = crate::R<#fty, #name_pc_a>;
+                        pub type #name_pc_r = crate::FieldReader<#fty, #name_pc_a>;
                     });
                 } else {
                     let has_reserved_variant = evs.values.len() != (1 << width);
@@ -463,7 +463,7 @@ pub fn fields(
 
                     mod_items.extend(quote! {
                         #[doc = #readerdoc]
-                        pub type #name_pc_r = crate::R<#fty, #name_pc_a>;
+                        pub type #name_pc_r = crate::FieldReader<#fty, #name_pc_a>;
                         impl #name_pc_r {
                             #enum_items
                         }
@@ -472,7 +472,7 @@ pub fn fields(
             } else {
                 mod_items.extend(quote! {
                     #[doc = #readerdoc]
-                    pub type #name_pc_r = crate::R<#fty, #fty>;
+                    pub type #name_pc_r = crate::FieldReader<#fty, #fty>;
                 })
             }
         }


### PR DESCRIPTION
Shuffling around type and trait definitions with the goal of improving the generated API & documentation.  Some highlights:

- Moves relevant trait impls from register type alias to register spec ZST, which fixes #459 and improves documentation output.
- Removes internal use of register type alias in favor of transparent usage of `Reg<..>`.  While the type alias is convenient, it hides critical implementation details.
- Wraps register reader/writer and field readers in newtype wrappers, which significantly improves the documentation output.

My testing so far has been admittedly much too limited given the scope of the changes.  However, for the binaries I've checked, the assembly output is identical before and after these changes, suggesting that they are all indeed only type-level cleanup.  I've also not run into any examples of user code breakage, despite the public API changes (though I would not be suprised to find some).  Spot checking with `scd2rust-regress` has found no issues so far.

Some notable design decisions worth discussing:

- The register spec ZST becomes much more important, so I've renamed it to remove the leading underscore.  To avoid conflicting with the register type alias, I've moved it into the register module.  Should the name have a suffix?  Should it be located in the parent module alongside the (now less-important) type alias?
- I've removed internal use (notably on generated `RegisterBlock`s) of the register type alias, as I think it adds a speed bump to understanding how the generated code works.  Should the alias continue to be used there instead?
- If breaking changes were on the table, I'd suggest changing the API of `Reg::write`.  Requiring the closure to return the input doesn't seem like the right thing to do.  It sows doubt about how exactly the changes propagate, and it makes one-liners slightly shorter at the expense of making multi-line closures an extra line.

Some documentation highlights:

- Boolean readers now show accessor options directly.
![svd2rust-bool-field](https://user-images.githubusercontent.com/793969/89549209-067c3d00-d7d6-11ea-859d-63f8575ad590.png)

- Field readers and writers show `bits` accessors.
![svd2rust-reg-reader](https://user-images.githubusercontent.com/793969/89549240-13992c00-d7d6-11ea-9ada-89f9d63cb6f5.png)
![svd2rust-reg-writer-2](https://user-images.githubusercontent.com/793969/89575804-566dfa80-d7fc-11ea-9bc2-3a3d0f3b49fb.png)

- Generic `R` type **doesn't** show every specific type's impls.
![svd2rust-generic-r-impls](https://user-images.githubusercontent.com/793969/89549303-26136580-d7d6-11ea-8756-6ce408c2af2c.png)