### PR TITLE
Register spec & traits

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -35,10 +35,7 @@ pub struct Reg<REG: Register> {
 
 unsafe impl<REG: Register> Send for Reg<REG> where REG::Ux: Send {}
 
-impl<REG: Register> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Register> Reg<REG> {
     /// Returns the underlying memory address of register.
     ///
     /// ```ignore
@@ -50,10 +47,7 @@ where
     }
 }
 
-impl<REG: Readable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Readable> Reg<REG> {
     /// Reads the contents of a `Readable` register.
     ///
     /// You can read the raw contents of a register by using `bits`:
@@ -75,10 +69,7 @@ where
     }
 }
 
-impl<REG: Resettable + Writable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Resettable + Writable> Reg<REG> {
     /// Writes the reset value to `Writable` register.
     ///
     /// Resets the register to its initial state.
@@ -119,7 +110,7 @@ where
 
 impl<REG: Writable> Reg<REG>
 where
-    REG::Ux: Copy + Default,
+    REG::Ux: Default,
 {
     /// Writes 0 to a `Writable` register.
     ///
@@ -139,10 +130,7 @@ where
     }
 }
 
-impl<REG: Readable + Writable> Reg<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Readable + Writable> Reg<REG> {
     /// Modifies the contents of the register by reading and then writing it.
     ///
     /// E.g. to do a read-modify-write sequence to change parts of a register:
@@ -191,10 +179,7 @@ pub struct R<REG: Register> {
     _reg: marker::PhantomData<REG>,
 }
 
-impl<REG: Register> R<REG>
-where
-    REG::Ux: Copy,
-{
+impl<REG: Register> R<REG> {
     /// Reads raw bits from register.
     #[inline(always)]
     pub fn bits(&self) -> REG::Ux {

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -198,24 +198,6 @@ where
     }
 }
 
-impl<REG: Register<Ux=bool>> R<REG> {
-    /// Value of the field as raw bits.
-    #[inline(always)]
-    pub fn bit(&self) -> bool {
-        self.bits
-    }
-    /// Returns `true` if the bit is clear (0).
-    #[inline(always)]
-    pub fn bit_is_clear(&self) -> bool {
-        !self.bit()
-    }
-    /// Returns `true` if the bit is set (1).
-    #[inline(always)]
-    pub fn bit_is_set(&self) -> bool {
-        self.bit()
-    }
-}
-
 /// Register writer.
 ///
 /// Used as an argument to the closures in the `write` and `modify` methods of the register.

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -9,20 +9,20 @@ pub trait Register {
 /// Trait implemented by readable registers to enable the `read` method.
 ///
 /// Registers marked with `Writable` can be also `modify`'ed.
-pub trait ReadableRegister: Register {}
+pub trait Readable: Register {}
 
 /// Trait implemented by writeable registers.
 ///
 /// This enables the  `write`, `write_with_zero` and `reset` methods.
 ///
 /// Registers marked with `Readable` can be also `modify`'ed.
-pub trait WritableRegister: Register {}
+pub trait Writable: Register {}
 
 /// Reset value of the register.
 ///
 /// This value is the initial value for the `write` method. It can also be directly written to the
 /// register by using the `reset` method.
-pub trait ResettableRegister: Register {
+pub trait Resettable: Register {
     /// Reset value of the register.
     fn reset_value() -> Self::Ux;
 }
@@ -50,7 +50,7 @@ where
     }
 }
 
-impl<REG: ReadableRegister> Reg<REG>
+impl<REG: Readable> Reg<REG>
 where
     REG::Ux: Copy,
 {
@@ -75,7 +75,7 @@ where
     }
 }
 
-impl<REG: ResettableRegister + WritableRegister> Reg<REG>
+impl<REG: Resettable + Writable> Reg<REG>
 where
     REG::Ux: Copy,
 {
@@ -117,7 +117,7 @@ where
     }
 }
 
-impl<REG: WritableRegister> Reg<REG>
+impl<REG: Writable> Reg<REG>
 where
     REG::Ux: Copy + Default,
 {
@@ -139,7 +139,7 @@ where
     }
 }
 
-impl<REG: ReadableRegister + WritableRegister> Reg<REG>
+impl<REG: Readable + Writable> Reg<REG>
 where
     REG::Ux: Copy,
 {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -158,7 +158,7 @@ pub fn render(
         #[doc(hidden)]
         pub struct #u_name_pc;
 
-        impl crate::Register for #u_name_pc {
+        impl crate::RegisterSpec for #u_name_pc {
             type Ux = #rty;
         }
     });

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -144,12 +144,10 @@ pub fn render(
         .as_str();
     }
     out.extend(quote! {
-        #[doc = #doc]
         pub type #name_pc = crate::Reg<#name_sc::#name_uc_spec>;
     });
     mod_items.extend(quote! {
-        #[allow(missing_docs)]
-        #[doc(hidden)]
+        #[doc = #doc]
         pub struct #name_uc_spec;
 
         impl crate::RegisterSpec for #name_uc_spec {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -71,7 +71,7 @@ pub fn render(
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::ResetValue for super::#name_pc {
+                impl crate::ResettableRegister for super::#u_name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -152,11 +152,15 @@ pub fn render(
     }
     out.extend(quote! {
         #[doc = #doc]
-        pub type #name_pc = crate::Reg<#rty, #u_name_pc>;
+        pub type #name_pc = crate::Reg<#u_name_pc>;
 
         #[allow(missing_docs)]
         #[doc(hidden)]
         pub struct #u_name_pc;
+
+        impl crate::Register for #u_name_pc {
+            type Ux = #rty;
+        }
     });
 
     if can_read {
@@ -166,7 +170,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::Readable for #name_pc {}
+            impl crate::ReadableRegister for #u_name_pc {}
         });
     }
     if can_write {
@@ -176,7 +180,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::Writable for #name_pc {}
+            impl crate::WritableRegister for #u_name_pc {}
         });
     }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -143,7 +143,12 @@ pub fn render(
         )
         .as_str();
     }
+    let alias_doc = format!(
+        "{} register accessor: an alias for `Reg<{}>`",
+        name, name_uc_spec,
+    );
     out.extend(quote! {
+        #[doc = #alias_doc]
         pub type #name_pc = crate::Reg<#name_sc::#name_uc_spec>;
     });
     mod_items.extend(quote! {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -177,7 +177,7 @@ pub fn render(
         });
     }
     if let Some(rv) = res_val.map(util::hex) {
-        let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
+        let doc = format!("`reset()` method sets {} to value {}", register.name, &rv);
         out.extend(quote! {
             #[doc = #doc]
             impl crate::Resettable for #u_name_pc {

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -71,7 +71,7 @@ pub fn render(
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
             mod_items.extend(quote! {
                 #[doc = #doc]
-                impl crate::ResettableRegister for super::#u_name_pc {
+                impl crate::Resettable for super::#u_name_pc {
                     #[inline(always)]
                     fn reset_value() -> Self::Ux { #rv }
                 }
@@ -170,7 +170,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::ReadableRegister for #u_name_pc {}
+            impl crate::Readable for #u_name_pc {}
         });
     }
     if can_write {
@@ -180,7 +180,7 @@ pub fn render(
         );
         out.extend(quote! {
             #[doc = #doc]
-            impl crate::WritableRegister for #u_name_pc {}
+            impl crate::Writable for #u_name_pc {}
         });
     }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -55,7 +55,7 @@ pub fn render(
         let desc = format!("Reader of register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type R = crate::R<#rty, super::#name_pc>;
+            pub type R = crate::R<super::#u_name_pc>;
         });
         methods.push("read");
     }
@@ -65,7 +65,7 @@ pub fn render(
         let desc = format!("Writer for register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type W = crate::W<#rty, super::#name_pc>;
+            pub type W = crate::W<super::#u_name_pc>;
         });
         if let Some(rv) = res_val.map(util::hex) {
             let doc = format!("Register {} `reset()`'s with value {}", register.name, &rv);
@@ -381,7 +381,7 @@ pub fn fields(
 
                     mod_items.extend(quote! {
                         #[doc = #readerdoc]
-                        pub type #name_pc_r = crate::R<#fty, #name_pc_a>;
+                        pub type #name_pc_r = crate::FieldReader<#fty, #name_pc_a>;
                     });
                 } else {
                     let has_reserved_variant = evs.values.len() != (1 << width);
@@ -463,7 +463,7 @@ pub fn fields(
 
                     mod_items.extend(quote! {
                         #[doc = #readerdoc]
-                        pub type #name_pc_r = crate::R<#fty, #name_pc_a>;
+                        pub type #name_pc_r = crate::FieldReader<#fty, #name_pc_a>;
                         impl #name_pc_r {
                             #enum_items
                         }
@@ -472,7 +472,7 @@ pub fn fields(
             } else {
                 mod_items.extend(quote! {
                     #[doc = #readerdoc]
-                    pub type #name_pc_r = crate::R<#fty, #fty>;
+                    pub type #name_pc_r = crate::FieldReader<#fty, #fty>;
                 })
             }
         }

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -21,7 +21,7 @@ pub fn render(
     let name = util::name_of(register);
     let span = Span::call_site();
     let name_pc = Ident::new(&name.to_sanitized_upper_case(), span);
-    let u_name_pc = Ident::new(&format!("_{}", &name.to_sanitized_upper_case()), span);
+    let name_uc_spec = Ident::new(&format!("{}_SPEC", &name.to_sanitized_upper_case()), span);
     let name_sc = Ident::new(&name.to_sanitized_snake_case(), span);
     let rsize = register
         .size
@@ -57,7 +57,7 @@ pub fn render(
         let desc = format!("Reader of register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type R = crate::R<super::#u_name_pc>;
+            pub type R = crate::R<#name_uc_spec>;
         });
         methods.push("read");
     }
@@ -66,7 +66,7 @@ pub fn render(
         let desc = format!("Writer for register {}", register.name);
         mod_items.extend(quote! {
             #[doc = #desc]
-            pub type W = crate::W<super::#u_name_pc>;
+            pub type W = crate::W<#name_uc_spec>;
         });
         methods.push("write_with_zero");
         if can_reset {
@@ -138,49 +138,50 @@ pub fn render(
 
     if name_sc != "cfg" {
         doc += format!(
-            "\n\nFor information about available fields see [{0}]({0}) module",
+            "\n\nFor information about available fields see [{0}](index.html) module",
             &name_sc
         )
         .as_str();
     }
     out.extend(quote! {
         #[doc = #doc]
-        pub type #name_pc = crate::Reg<#u_name_pc>;
-
+        pub type #name_pc = crate::Reg<#name_sc::#name_uc_spec>;
+    });
+    mod_items.extend(quote! {
         #[allow(missing_docs)]
         #[doc(hidden)]
-        pub struct #u_name_pc;
+        pub struct #name_uc_spec;
 
-        impl crate::RegisterSpec for #u_name_pc {
+        impl crate::RegisterSpec for #name_uc_spec {
             type Ux = #rty;
         }
     });
 
     if can_read {
         let doc = format!(
-            "`read()` method returns [{0}::R]({0}::R) reader structure",
+            "`read()` method returns [{0}::R](R) reader structure",
             &name_sc
         );
-        out.extend(quote! {
+        mod_items.extend(quote! {
             #[doc = #doc]
-            impl crate::Readable for #u_name_pc {}
+            impl crate::Readable for #name_uc_spec {}
         });
     }
     if can_write {
         let doc = format!(
-            "`write(|w| ..)` method takes [{0}::W]({0}::W) writer structure",
+            "`write(|w| ..)` method takes [{0}::W](W) writer structure",
             &name_sc
         );
-        out.extend(quote! {
+        mod_items.extend(quote! {
             #[doc = #doc]
-            impl crate::Writable for #u_name_pc {}
+            impl crate::Writable for #name_uc_spec {}
         });
     }
     if let Some(rv) = res_val.map(util::hex) {
         let doc = format!("`reset()` method sets {} to value {}", register.name, &rv);
-        out.extend(quote! {
+        mod_items.extend(quote! {
             #[doc = #doc]
-            impl crate::Resettable for #u_name_pc {
+            impl crate::Resettable for #name_uc_spec {
                 #[inline(always)]
                 fn reset_value() -> Self::Ux { #rv }
             }


### PR DESCRIPTION
Part 1 of #463.

- Publishes the register spec zero-sized type and moves all relevant register traits to that struct, which fixes #459 and improves generated documentation.
- Removes the extra type parameter on `Reg`, making the register spec the sole authority on the shape of the register (but not its address).

One thing that's changed since the previous PR, this renames the spec struct so that it won't cause a conflict on NXP, Freescale, and possibly other architectures.  I've gone with `register::REGISTER_SPEC` since that seems reasonably clear and I can't think of how it would cause a conflict (but I'm ready to be proven wrong since I've tried several ideas only to be stymied by various architectures' oddball register naming patterns).

I'd prefer the spec to be in the parent module, but I can't come up with a way to do that which guarantees that the generated code will be free from naming conflicts.  This seems good enough, plus it maintains the rule that when we make up a name it belongs in the child mod (except for `RegisterBlock`).

There is potential for breaking changes here, though the impact seems pretty minimal.  Specifically:
- If users referred to the traits in `mod generic`, their usage would break.  Writing code referring to those traits was previously pretty awkward (see #463), and this PR makes such usage much more ergonomic, so it would seem to be a net benefit.
- If users named the full reader/writer incantation the reference would break.  It doesn't seem users are likely to name the readers/writers at all, but if they do it seems very likely they would use the type alias.
- If users named the previously `#[docs(hidden)] ` spec struct the reference would break.  I don't see why they would have done so.
- If users patched something in to the generated module with the same name as our new register spec, it would break.  That case seems highly unlikely.

r? @burrbull 