### PR TITLE
Allow unused FieldReader

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -243,6 +243,7 @@ where
     U: Copy,
 {
     /// Creates a new instance of the reader.
+    #[allow(unused)]
     #[inline(always)]
     pub(crate) fn new(bits: U) -> Self {
         Self {


### PR DESCRIPTION
I'm developing code that's general across AVR chips.  I'd like to depend on the shared parts of Rahix/avr-device (see https://github.com/Rahix/avr-device/pull/44).  When compiling without any specific device feature enabled, there are no users of the `FieldReader::new` method.  This PR skips the lint for this case.

This is somewhat related to #427 but not exactly.