### PR TITLE
Use xtensa-lx

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -694,13 +694,15 @@ main() {
             echo '[dependencies.bare-metal]' >> $td/Cargo.toml
             echo 'version = "0.2.0"' >> $td/Cargo.toml
 
-            echo '[dependencies.xtensa-lx6]' >> $td/Cargo.toml
-            echo 'version = "0.1.0"' >> $td/Cargo.toml
+            echo '[dependencies.xtensa-lx]' >> $td/Cargo.toml
+            echo 'version = "0.3.0"' >> $td/Cargo.toml
+            echo 'features = ["lx6"]' >> $td/Cargo.toml
 
-            echo '[dependencies.xtensa-lx6-rt]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
+            echo '[dependencies.xtensa-lx-rt]' >> $td/Cargo.toml
+            echo 'version = "0.5.0"' >> $td/Cargo.toml
+            echo 'features = ["lx6"]' >> $td/Cargo.toml
 
-            test_svd_for_target xtensalx6 https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
+            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
         ;;
 
     esac

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -702,7 +702,7 @@ main() {
             echo 'version = "0.5.0"' >> $td/Cargo.toml
             echo 'features = ["lx6"]' >> $td/Cargo.toml
 
-            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd
+            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/esp-rs/esp32/master/svd/esp32.svd
         ;;
 
     esac

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -134,7 +134,7 @@ pub fn test(
             CortexM => CRATES_CORTEX_M.iter(),
             RiscV => CRATES_RISCV.iter(),
             Msp430 => CRATES_MSP430.iter(),
-            XtensaLX6 => CRATES_XTENSALX6.iter(),
+            XtensaLX => CRATES_XTENSALX6.iter(),
         })
         .chain(PROFILE_ALL.iter())
         .chain(FEATURES_ALL.iter())
@@ -167,7 +167,7 @@ pub fn test(
         CortexM => "cortex-m",
         Msp430 => "msp430",
         RiscV => "riscv",
-        XtensaLX6 => "xtensalx6",
+        XtensaLX => "xtensa-lx",
     };
     let mut svd2rust_bin = Command::new(bin_path);
     if nightly {
@@ -184,14 +184,14 @@ pub fn test(
         true,
         "svd2rust",
         Some(&lib_rs_file)
-            .filter(|_| (t.arch != CortexM) && (t.arch != Msp430) && (t.arch != XtensaLX6)),
+            .filter(|_| (t.arch != CortexM) && (t.arch != Msp430) && (t.arch != XtensaLX)),
         Some(&svd2rust_err_file),
         &[],
     )?;
     process_stderr_paths.push(svd2rust_err_file);
 
     match t.arch {
-        CortexM | Msp430 | XtensaLX6 => {
+        CortexM | Msp430 | XtensaLX => {
             // TODO: Give error the path to stderr
             fs::rename(path_helper_base(&chip_dir, &["lib.rs"]), &lib_rs_file)
                 .chain_err(|| "While moving lib.rs file")?

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -7,7 +7,7 @@ pub enum Architecture {
     CortexM,
     Msp430,
     RiscV,
-    XtensaLX6,
+    XtensaLX,
 }
 
 #[derive(Debug)]
@@ -4229,7 +4229,7 @@ pub const TESTS: &[&TestCase] = &[
         run_when: Always,
     },
     &TestCase {
-        arch: XtensaLX6,
+        arch: XtensaLX,
         mfgr: Espressif,
         chip: "esp32",
         svd_url: Some(

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -198,7 +198,7 @@ pub fn render(
         Target::CortexM => Some(Ident::new("cortex_m", span)),
         Target::Msp430 => Some(Ident::new("msp430", span)),
         Target::RISCV => Some(Ident::new("riscv", span)),
-        Target::XtensaLX6 => Some(Ident::new("xtensa_lx6", span)),
+        Target::XtensaLX => Some(Ident::new("xtensa_lx", span)),
         Target::None => None,
     }
     .map(|krate| {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -126,7 +126,7 @@ pub fn render(
             });
         }
         Target::RISCV => {}
-        Target::XtensaLX6 => {
+        Target::XtensaLX => {
             for name in &names {
                 writeln!(device_x, "PROVIDE({} = DefaultHandler);", name)?;
             }
@@ -216,7 +216,7 @@ pub fn render(
             _ => "C",
         };
 
-        if target != Target::CortexM && target != Target::Msp430 && target != Target::XtensaLX6 {
+        if target != Target::CortexM && target != Target::Msp430 && target != Target::XtensaLX {
             mod_items.extend(quote! {
                 #[cfg(feature = "rt")]
                 #[macro_export]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@
 //!
 //! `svd2rust` supports Cortex-M, MSP430, RISCV and Xtensa LX6 microcontrollers. The generated crate can
 //! be tailored for either architecture using the `--target` flag. The flag accepts "cortex-m",
-//! "msp430", "riscv", "xtensalx6" and "none" as values. "none" can be used to generate a crate that's
+//! "msp430", "riscv", "xtensa-lx" and "none" as values. "none" can be used to generate a crate that's
 //! architecture agnostic and that should work for architectures that `svd2rust` doesn't currently
 //! know about like the Cortex-A architecture.
 //!

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,7 +100,7 @@ fn run() -> Result<()> {
     file.write_all(data.as_ref())
         .expect("Could not write code to lib.rs");
 
-    if target == Target::CortexM || target == Target::Msp430 || target == Target::XtensaLX6 {
+    if target == Target::CortexM || target == Target::Msp430 || target == Target::XtensaLX {
         writeln!(File::create("device.x")?, "{}", device_x)?;
         writeln!(File::create("build.rs")?, "{}", build_rs())?;
     }

--- a/src/util.rs
+++ b/src/util.rs
@@ -18,7 +18,7 @@ pub enum Target {
     CortexM,
     Msp430,
     RISCV,
-    XtensaLX6,
+    XtensaLX,
     None,
 }
 
@@ -28,7 +28,7 @@ impl Target {
             "cortex-m" => Target::CortexM,
             "msp430" => Target::Msp430,
             "riscv" => Target::RISCV,
-            "xtensalx6" => Target::XtensaLX6,
+            "xtensa-lx" => Target::XtensaLX,
             "none" => Target::None,
             _ => bail!("unknown target {}", s),
         })


### PR DESCRIPTION
The xtensa runtime and device crates have been merged into a single device and runtime crate, feature gating the CPU features.

* s/XtensaLX6/XtensaLX/g
* s/"xtensalx6"/"xtensa-lx"/g
* Replaces lx6 with the generic lx crate
* Updates the CI script accordingly