### PR TITLE
Writable::Writer needs DerefMut trait bound

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -21,7 +21,7 @@ pub trait Readable: RegisterSpec {
 /// Registers marked with `Readable` can be also `modify`'ed.
 pub trait Writable: RegisterSpec {
     /// Writer type argument to `write`, et al.
-    type Writer: core::convert::From<W<Self>> + core::ops::Deref<Target = W<Self>>;
+    type Writer: core::convert::From<W<Self>> + core::ops::DerefMut<Target = W<Self>>;
 }
 
 /// Reset value of the register.


### PR DESCRIPTION
Otherwise, a call to `bits` in the closure passed to `write`/`modify` in a function where the register is bound only on the `Writable` trait will fail to typecheck.

This only causes an issue for code written to be generic over a `Writable` register, so I suspect I'm the only one that's so far been bitten by the bug.  In any case, apologies for shipping broken code!