### PR TITLE
Implement new InterruptNumber trait from next cortex-m release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Don't generate pre Edition 2018 `extern crate` statements anymore
 
+- [breaking-change] Cortex-M PACs now rely on
+  `cortex_m::interrupt::InterruptNumber` instead of `bare_metal::Nr` for
+  interrupt number handling. The minimum supported `cortex-m` version is now
+  **0.7** and `bare-metal` is not a dependency anymore.
+
 ## [v0.17.0] - 2019-12-31
 
 ### Fixed

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -68,17 +68,14 @@ main() {
 
     # test crate
     cargo init --name foo $td
-    echo 'cortex-m = "0.6.0"' >> $td/Cargo.toml
-    echo 'cortex-m-rt = "0.6.9"' >> $td/Cargo.toml
+    echo 'cortex-m = "0.7.0"' >> $td/Cargo.toml
+    echo 'cortex-m-rt = "0.6.13"' >> $td/Cargo.toml
     echo 'vcell = "0.1.0"' >> $td/Cargo.toml
     echo '[profile.dev]' >> $td/Cargo.toml
     echo 'incremental = false' >> $td/Cargo.toml
 
     case $VENDOR in
         Atmel)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD missing resetValue
             # test_svd AT91SAM9CN11
             # test_svd AT91SAM9CN12
@@ -162,9 +159,6 @@ main() {
         ;;
 
         Freescale)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD bad enumeratedValue value
             # test_svd MKV56F20
             # test_svd MKV56F22
@@ -313,9 +307,6 @@ main() {
         ;;
 
         Fujitsu)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd MB9AF10xN
             test_svd MB9AF10xR
@@ -420,9 +411,6 @@ main() {
         ;;
 
         Holtek)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd ht32f125x
             test_svd ht32f175x
@@ -430,9 +418,6 @@ main() {
         ;;
 
         Nordic)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD two enumeratedValues have the same value
             # test_svd nrf52
 
@@ -441,18 +426,12 @@ main() {
         ;;
 
         Nuvoton)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd M051_Series
             test_svd NUC100_Series
         ;;
 
         NXP)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             test_svd MK22F25612
             test_svd MKW41Z4
 
@@ -517,9 +496,6 @@ main() {
         ;;
 
         SiliconLabs)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # #99 regression tests
             test_svd SIM3C1x4_SVD
             test_svd SIM3C1x6_SVD
@@ -536,9 +512,6 @@ main() {
         ;;
 
         Spansion)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd MB9AF12xK
             test_svd MB9AF12xL
@@ -634,9 +607,6 @@ main() {
         ;;
 
         STMicro)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # OK
             test_svd STM32F030
             test_svd STM32F031x
@@ -676,9 +646,6 @@ main() {
         ;;
 
         Toshiba)
-            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
-            echo 'version = "0.2.0"' >> $td/Cargo.toml
-
             # BAD-SVD resetValue is bigger than the register size
             # test_svd M365
             # test_svd M367

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -7,7 +7,7 @@ use std::process::{Command, Output};
 
 const CRATES_ALL: &[&str] = &["bare-metal = \"0.2.0\"", "vcell = \"0.1.0\""];
 const CRATES_MSP430: &[&str] = &["msp430 = \"0.2.2\""];
-const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.6.0\"", "cortex-m-rt = \"0.6.0\""];
+const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.7.0\"", "cortex-m-rt = \"0.6.13\""];
 const CRATES_RISCV: &[&str] = &["riscv = \"0.5.0\"", "riscv-rt = \"0.6.0\""];
 const CRATES_XTENSALX6: &[&str] = &["xtensa-lx6-rt = \"0.2.0\"", "xtensa-lx6 = \"0.1.0\""];
 const PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -155,9 +155,9 @@ pub fn render(
 
     let self_token = quote!(self);
     let (enum_repr, nr_expr) = if variants.is_empty() {
-        (quote!(), quote!(match *#self_token {}))
+        (quote!(), quote!(match #self_token {}))
     } else {
-        (quote!(#[repr(u8)]), quote!(*#self_token as u8))
+        (quote!(#[repr(u16)]), quote!(#self_token as u16))
     };
 
     if target == Target::Msp430 {
@@ -180,9 +180,9 @@ pub fn render(
                 #variants
             }
 
-            unsafe impl bare_metal::Nr for Interrupt {
+            unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
                 #[inline(always)]
-                fn nr(&#self_token) -> u8 {
+                fn number(#self_token) -> u16 {
                     #nr_expr
                 }
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,19 +53,18 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `bare-metal` v0.2.x, `cortex-m` v0.5.x, `cortex-m-rt` >=v0.6.5 and `vcell` v0.1.x. Furthermore
+//! `cortex-m` v0.7, `cortex-m-rt` >=v0.6.13 and `vcell` v0.1.x. Furthermore
 //! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
-//! bare-metal = "0.2.0"
-//! cortex-m = "0.5.8"
+//! cortex-m = "0.7"
 //! vcell = "0.1.0"
 //!
 //! [dependencies.cortex-m-rt]
 //! optional = true
-//! version = "0.6.5"
+//! version = "0.6.13"
 //!
 //! [features]
 //! rt = ["cortex-m-rt/device"]


### PR DESCRIPTION
This eliminates the bare-metal and cortex-m-rt dependencies for Cortex-M
and thus changes CI and svd2rust-regress accordingly.

Replaces #455

Signed-off-by: Daniel Egger <daniel@eggers-club.de>