### PR TITLE
Fix derivedFrom enumerated values

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -430,30 +430,15 @@ pub fn fields(
                 evs_r = Some(evs.clone());
 
                 if let Some(base) = base {
-                    let pc = util::replace_suffix(base.field, "");
-                    let pc = pc.to_sanitized_upper_case();
-                    let base_pc_r = Ident::new(&(pc + "_A"), span);
-                    derive_from_base(mod_items, &base, &name_pc_a, &base_pc_r, &description);
+                    let pc_orig = util::replace_suffix(base.field, "");
 
-                    mod_items.extend(quote! {
-                        #[doc = #readerdoc]
-                        pub struct #name_pc_r(crate::FieldReader<#fty, #name_pc_a>);
+                    let pc = pc_orig.to_sanitized_upper_case();
+                    let base_pc_a = Ident::new(&(pc + "_A"), span);
+                    derive_from_base(mod_items, &base, &name_pc_a, &base_pc_a, &description);
 
-                        impl #name_pc_r {
-                            pub(crate) fn new(bits: #fty) -> Self {
-                                #name_pc_r(crate::FieldReader::new(bits))
-                            }
-                        }
-
-                        impl core::ops::Deref for #name_pc_r {
-                            type Target = crate::FieldReader<#fty, #name_pc_a>;
-
-                            #[inline(always)]
-                            fn deref(&self) -> &Self::Target {
-                                &self.0
-                            }
-                        }
-                    });
+                    let pc = pc_orig.to_sanitized_upper_case();
+                    let base_pc_r = Ident::new(&(pc + "_R"), span);
+                    derive_from_base(mod_items, &base, &name_pc_r, &base_pc_r, &readerdoc);
                 } else {
                     let has_reserved_variant = evs.values.len() != (1 << width);
                     let variants = Variant::from_enumerated_values(evs)?;


### PR DESCRIPTION
derivedFrom FieldReaders should always be a type alias for the base FieldReader, rather than each their own newtype.

~I believe this fixes #474, however I'm having trouble getting a working development environment set up for the `esp32` project.~

~@MabezDev, would you mind giving this a spin and posting a diff of the generated code?~

Figured out my issue, the generated code looks good, e.g.:

```diff
diff --git a/src/rtccntl/wdtconfig0.rs b/src/rtccntl/wdtconfig0.rs
index 6851bff..089e4e1 100644
--- a/src/rtccntl/wdtconfig0.rs
+++ b/src/rtccntl/wdtconfig0.rs
@@ -186,19 +186,7 @@ impl<'a> WDT_STG0_W<'a> {
 #[doc = ""]
 pub type WDT_STG1_A = WDT_STG0_A;
 #[doc = "Field `WDT_STG1` reader - "]
-pub struct WDT_STG1_R(crate::FieldReader<u8, WDT_STG1_A>);
-impl WDT_STG1_R {
-    pub(crate) fn new(bits: u8) -> Self {
-        WDT_STG1_R(crate::FieldReader::new(bits))
-    }
-}
-impl core::ops::Deref for WDT_STG1_R {
-    type Target = crate::FieldReader<u8, WDT_STG1_A>;
-    #[inline(always)]
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
-}
+pub type WDT_STG1_R = WDT_STG0_R;
 #[doc = "Field `WDT_STG1` writer - "]
 pub struct WDT_STG1_W<'a> {
     w: &'a mut W,
```