### PR TITLE
Add repr(transparent) to Reg struct

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -34,6 +34,7 @@ pub trait Resettable: RegisterSpec {
 }
 
 /// This structure provides volatile access to registers.
+#[repr(transparent)]
 pub struct Reg<REG: RegisterSpec> {
     register: vcell::VolatileCell<REG::Ux>,
     _marker: marker::PhantomData<REG>,


### PR DESCRIPTION
To guarantee that the register has the proper layout so that the [cast](https://github.com/rust-embedded/svd2rust/blob/971814070cd7be848d3c6524734192903de66866/src/generate/peripheral.rs#L63) of an integer to a `*const RegisterBlock` is sound.

Note that this is necessary but not sufficient.  The underlying `VolatileCell` also currently uses the default repr.  There is an open [issue](https://github.com/japaric/vcell/issues/5) and [PR](https://github.com/japaric/vcell/pull/6/files) to address the concern.