### PR TITLE
Update the min `vcell` version to v0.1.2

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -70,7 +70,7 @@ main() {
     cargo init --name foo $td
     echo 'cortex-m = "0.7.0"' >> $td/Cargo.toml
     echo 'cortex-m-rt = "0.6.13"' >> $td/Cargo.toml
-    echo 'vcell = "0.1.0"' >> $td/Cargo.toml
+    echo 'vcell = "0.1.2"' >> $td/Cargo.toml
     echo '[profile.dev]' >> $td/Cargo.toml
     echo 'incremental = false' >> $td/Cargo.toml
 

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -5,7 +5,7 @@ use std::io::prelude::*;
 use std::path::PathBuf;
 use std::process::{Command, Output};
 
-const CRATES_ALL: &[&str] = &["bare-metal = \"0.2.0\"", "vcell = \"0.1.0\""];
+const CRATES_ALL: &[&str] = &["bare-metal = \"0.2.0\"", "vcell = \"0.1.2\""];
 const CRATES_MSP430: &[&str] = &["msp430 = \"0.2.2\""];
 const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.7.0\"", "cortex-m-rt = \"0.6.13\""];
 const CRATES_RISCV: &[&str] = &["riscv = \"0.5.0\"", "riscv-rt = \"0.6.0\""];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,14 +53,14 @@
 //! ```
 //!
 //! The resulting crate must provide an opt-in "rt" feature and depend on these crates:
-//! `cortex-m` v0.7, `cortex-m-rt` >=v0.6.13 and `vcell` v0.1.x. Furthermore
+//! `cortex-m` v0.7, `cortex-m-rt` >=v0.6.13 and `vcell` >=v0.1.2. Furthermore
 //! the "device" feature of `cortex-m-rt` must be enabled when the "rt" feature is enabled. The
 //! `Cargo.toml` of the device crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
 //! cortex-m = "0.7"
-//! vcell = "0.1.0"
+//! vcell = "0.1.2"
 //!
 //! [dependencies.cortex-m-rt]
 //! optional = true


### PR DESCRIPTION
`src/generate/generic.rs:53` contains an `as_ptr()` call on a vcell.
This was only added in `vcell` v0.1.1 (since yanked).

Thus, the generated crates only build with vcell v0.1.2