### PR TITLE
Expand derived clusters

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -307,6 +307,22 @@ impl U32Ext for u32 {
     }
 }
 
+/// Return the name of either register or cluster.
+pub fn erc_name(erc: &RegisterCluster) -> &String {
+    match erc {
+        RegisterCluster::Register(r) => &r.name,
+        RegisterCluster::Cluster(c) => &c.name,
+    }
+}
+
+/// Return the name of either register or cluster from which this register or cluster is derived.
+pub fn erc_derived_from(erc: &RegisterCluster) -> &Option<String> {
+    match erc {
+        RegisterCluster::Register(r) => &r.derived_from,
+        RegisterCluster::Cluster(c) => &c.derived_from,
+    }
+}
+
 /// Return only the clusters from the slice of either register or clusters.
 pub fn only_clusters(ercs: &[RegisterCluster]) -> Vec<&Cluster> {
     let clusters: Vec<&Cluster> = ercs


### PR DESCRIPTION
This PR addresses two issues encountered when attempting to process the svd file [here](https://raw.githubusercontent.com/renesas/fsp/master/ra/fsp/src/bsp/cmsis/Device/RENESAS/SVD/RA.svd).

1.  The SVD file defines a cluster in the 'R_GPT_ODC' peripheral that derives from a sibling cluster.  AFAICT from the SVD schema, this is allowed, and we should expand the cluster definition in the same way registers are handled.
2.  The SVD file contains many `EnumeratedValue`s that are "reserved", but aren't filtered out because they're named "other".  They have an `<isDefault>` child element, which is mutually exclusive with the `<value>` child element according to the SVD schema, i.e. they don't represent a value that we would want to define in the generated code, and so can be skipped.

When running `svd2rust-regress` locally 3 tests fail, but the same tests also fail on `master`, so it seems there's no indication of a regression here.

This seems to fix #462.
