### PR TITLE
Mips target

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         rust: [stable]
 
         # All vendor files we want to test on stable
-        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba]
+        VENDOR: [rustfmt, Atmel, Freescale, Fujitsu, Holtek, Microchip, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba]
 
         # The default target we're compiling on and for
         TARGET: [x86_64-unknown-linux-gnu]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Generated peripherals now implement `core::fmt::Debug`.
 
+- Support for MIPS MCU cores, in particular for PIC32MX microcontrollers
+
 ### Fixed
 
 - Keyword sanitizing (`async`)

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -417,6 +417,17 @@ main() {
             test_svd ht32f275x
         ;;
 
+        Microchip)
+            echo '[dependencies.bare-metal]' >> $td/Cargo.toml
+            echo 'version = "0.2.0"' >> $td/Cargo.toml
+
+            echo '[dependencies.mips-mcu]' >> $td/Cargo.toml
+            echo 'version = "0.1.0"' >> $td/Cargo.toml
+
+            test_svd_for_target mips https://raw.githubusercontent.com/kiffie/pic32-pac/master/pic32mx1xxfxxxb/PIC32MX170F256B.svd.patched
+            test_svd_for_target mips https://raw.githubusercontent.com/kiffie/pic32-pac/master/pic32mx2xxfxxxb/PIC32MX270F256B.svd.patched
+        ;;
+
         Nordic)
             # BAD-SVD two enumeratedValues have the same value
             # test_svd nrf52

--- a/ci/svd2rust-regress/src/main.rs
+++ b/ci/svd2rust-regress/src/main.rs
@@ -46,7 +46,7 @@ struct Opt {
     mfgr: Option<String>,
 
     /// Filter by architecture, case sensitive, may be combined with other filters
-    /// Options are: "CortexM", "RiscV", and "Msp430"
+    /// Options are: "CortexM", "RiscV", Mips, and "Msp430"
     #[structopt(
         short = "a",
         long = "architecture",

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -10,6 +10,7 @@ const CRATES_MSP430: &[&str] = &["msp430 = \"0.2.2\""];
 const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.7.0\"", "cortex-m-rt = \"0.6.13\""];
 const CRATES_RISCV: &[&str] = &["riscv = \"0.5.0\"", "riscv-rt = \"0.6.0\""];
 const CRATES_XTENSALX6: &[&str] = &["xtensa-lx6-rt = \"0.2.0\"", "xtensa-lx6 = \"0.1.0\""];
+const CRATES_MIPS: &[&str] = &["mips-mcu = \"0.1.0\""];
 const PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];
 const FEATURES_ALL: &[&str] = &["[features]"];
 
@@ -129,6 +130,7 @@ pub fn test(
         .chain(match &t.arch {
             CortexM => CRATES_CORTEX_M.iter(),
             RiscV => CRATES_RISCV.iter(),
+            Mips => CRATES_MIPS.iter(),
             Msp430 => CRATES_MSP430.iter(),
             XtensaLX => CRATES_XTENSALX6.iter(),
         })
@@ -158,6 +160,7 @@ pub fn test(
     let target = match t.arch {
         CortexM => "cortex-m",
         Msp430 => "msp430",
+        Mips => "mips",
         RiscV => "riscv",
         XtensaLX => "xtensa-lx",
     };
@@ -183,7 +186,7 @@ pub fn test(
     process_stderr_paths.push(svd2rust_err_file);
 
     match t.arch {
-        CortexM | Msp430 | XtensaLX => {
+        CortexM | Mips | Msp430 | XtensaLX => {
             // TODO: Give error the path to stderr
             fs::rename(path_helper_base(&chip_dir, &["lib.rs"]), &lib_rs_file)
                 .chain_err(|| "While moving lib.rs file")?

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -5,6 +5,7 @@ pub enum Architecture {
     // TODO: Coming soon!
     // Avr,
     CortexM,
+    Mips,
     Msp430,
     RiscV,
     XtensaLX,
@@ -16,6 +17,7 @@ pub enum Manufacturer {
     Freescale,
     Fujitsu,
     Holtek,
+    Microchip,
     Nordic,
     Nuvoton,
     NXP,
@@ -4234,6 +4236,26 @@ pub const TESTS: &[&TestCase] = &[
         chip: "esp32",
         svd_url: Some(
             "https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd",
+        ),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: Mips,
+        mfgr: Microchip,
+        chip: "pic32mx170f256b",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/kiffie/pic32-pac/master/pic32mx1xxfxxxb/PIC32MX170F256B.svd.patched",
+        ),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: Mips,
+        mfgr: Microchip,
+        chip: "pic32mx270f256b",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/kiffie/pic32-pac/master/pic32mx2xxfxxxb/PIC32MX270F256B.svd.patched",
         ),
         should_pass: true,
         run_when: Always,

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -199,6 +199,7 @@ pub fn render(
         Target::Msp430 => Some(Ident::new("msp430", span)),
         Target::RISCV => Some(Ident::new("riscv", span)),
         Target::XtensaLX => Some(Ident::new("xtensa_lx", span)),
+        Target::Mips => Some(Ident::new("mips_mcu", span)),
         Target::None => None,
     }
     .map(|krate| {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -150,6 +150,7 @@ pub fn render(
                 ];
             });
         }
+        Target::Mips => {}
         Target::None => {}
     }
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,6 +19,7 @@ pub enum Target {
     Msp430,
     RISCV,
     XtensaLX,
+    Mips,
     None,
 }
 
@@ -29,6 +30,7 @@ impl Target {
             "msp430" => Target::Msp430,
             "riscv" => Target::RISCV,
             "xtensa-lx" => Target::XtensaLX,
+            "mips" => Target::Mips,
             "none" => Target::None,
             _ => bail!("unknown target {}", s),
         })


### PR DESCRIPTION
r? @therealprof 

Hi all,

Willing to add some basic support for MIPS cores? This patch enables the Peripheral Singleton. I use svd2rust to create PACs for PIC32MX microcontroller.

Best regards,

Stephan 