### PR TITLE
unsafe write_with_zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- [breaking-change] make `write_with_zero` method `unsafe` because the way it is
+
 - [breaking-change] remove `Variant<U, ENUM_A>`, use `Option<ENUM_A>` instead
 
 - split out register size type (`RawType`) from `ResetValue` trait

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -123,7 +123,7 @@ where
     ///
     /// Similar to `write`, but unused bits will contain 0.
     #[inline(always)]
-    pub fn write_with_zero<F>(&self, f: F)
+    pub unsafe fn write_with_zero<F>(&self, f: F)
     where
         F: FnOnce(&mut REG::Writer) -> &mut W<REG>
     {


### PR DESCRIPTION
As 0 is not always correct value, `write_with_zero` can't be safe for all registers.