### PR TITLE
Emit code to bring generic module into scope when using `-g` option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Ignore default enumeratedValues.
 
+- Bring `generic` module into scope in `lib.rs` when using `-g` option.
+
 ### Changed
 
 - [breaking-change] remove `Variant<U, ENUM_A>`, use `Option<ENUM_A>` instead

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -146,6 +146,13 @@ pub fn render(
     let generic_file = std::str::from_utf8(include_bytes!("generic.rs"))?;
     if generic_mod {
         writeln!(File::create("generic.rs")?, "{}", generic_file)?;
+
+        out.extend(quote! {
+            #[allow(unused_imports)]
+            use generic::*;
+            ///Common register and bit access and modify traits
+            pub mod generic;
+        });
     } else {
         let tokens = syn::parse_file(generic_file)?.into_token_stream();
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -150,7 +150,7 @@ pub fn render(
         out.extend(quote! {
             #[allow(unused_imports)]
             use generic::*;
-            ///Common register and bit access and modify traits
+            #[doc="Common register and bit access and modify traits"]
             pub mod generic;
         });
     } else {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,10 @@
 //!
 //! If the `--target` flag is omitted `svd2rust` assumes the target is the Cortex-M architecture.
 //!
+//! If using the `--generic_mod` option, the emitted `generic.rs` needs to be moved to `src`, and
+//! [`form`](https://github.com/djmcgill/form) commit fcb397a or newer is required for splitting
+//! the emitted `lib.rs`.
+//!
 //! ## target = cortex-m
 //!
 //! When targeting the Cortex-M architecture, `svd2rust` will generate three files in the current


### PR DESCRIPTION
The -g option emits a separate file called generic.rs to split the generic code from the peripherals.

Right now the -g option requires a user to manually add something like the following lines to `lib.rs`:

```rust
use generic::*;
pub mod generic;
```

Otherwise compilation will fail with errors like the following:

```sh
     error[E0433]: failed to resolve: maybe a missing crate `FieldReader`?
   --> src\port_1_2\p2ifg.rs:111:25
    |
111 |         P2IFG2_R(crate::FieldReader::new(bits))
    |                         ^^^^^^^^^^^ maybe a missing crate `FieldReader`?
```

This patch automates adding the above code.