### PR TITLE
Add -m switch to create a module instead of a lib

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- New `-m` switch generates a `mod.rs` file instead of `lib.rs`, which can
+  be used as a module inside a crate without further modification.
+
 - Generated crates now contain the git commit hash and date of svd2rust
   compilation.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -515,7 +515,7 @@ pub fn generate(xml: &str, target: Target, nightly: bool) -> Result<Generation> 
 
     let device = svd::parse(xml)?;
     let mut device_x = String::new();
-    let items = generate::device::render(&device, target, nightly, false, &mut device_x)
+    let items = generate::device::render(&device, target, nightly, false, false, &mut device_x)
         .or(Err(SvdError::Render))?;
 
     let mut lib_rs = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,6 +46,12 @@ fn run() -> Result<()> {
                 .help("Push generic mod in separate file"),
         )
         .arg(
+            Arg::with_name("make_mod")
+                .long("make_mod")
+                .short("m")
+                .help("Create mod.rs instead of lib.rs, without inner attributes"),
+        )
+        .arg(
             Arg::with_name("log_level")
                 .long("log")
                 .short("l")
@@ -91,10 +97,19 @@ fn run() -> Result<()> {
     let nightly = matches.is_present("nightly_features");
 
     let generic_mod = matches.is_present("generic_mod");
+    let make_mod = matches.is_present("make_mod");
 
     let mut device_x = String::new();
-    let items = generate::device::render(&device, target, nightly, generic_mod, &mut device_x)?;
-    let mut file = File::create("lib.rs").expect("Couldn't create lib.rs file");
+    let items = generate::device::render(
+        &device,
+        target,
+        nightly,
+        generic_mod,
+        make_mod,
+        &mut device_x,
+    )?;
+    let filename = if make_mod { "mod.rs" } else { "lib.rs" };
+    let mut file = File::create(filename).expect("Couldn't create output file");
 
     let data = items.to_string().replace("] ", "]\n");
     file.write_all(data.as_ref())


### PR DESCRIPTION
Currently projects like stm32-rs have to strip out all the attributes during build to create a file suitable for use as a module. This PR adds a new `-m` switch instead, which causes a `mod.rs` file to be created without the inner attributes or the `pub mod generic`/`use generic::*` lines which would live in the top-level `lib.rs`.