### PR TITLE
Add `#[inline(always)]` to three generated methods.

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -70,6 +70,7 @@ pub fn render(
             }
 
             impl From<crate::R<#name_uc_spec>> for R {
+                #[inline(always)]
                 fn from(reader: crate::R<#name_uc_spec>) -> Self {
                     R(reader)
                 }
@@ -101,6 +102,7 @@ pub fn render(
             }
 
             impl From<crate::W<#name_uc_spec>> for W {
+                #[inline(always)]
                 fn from(writer: crate::W<#name_uc_spec>) -> Self {
                     W(writer)
                 }
@@ -161,6 +163,7 @@ pub fn render(
 
         mod_items.extend(quote! {
             #[doc = "Writes raw bits to the register."]
+            #[inline(always)]
             pub unsafe fn bits(&mut self, bits: #rty) -> &mut Self {
                 self.0.bits(bits);
                 self


### PR DESCRIPTION
All three appear to be trivial wrappers, making the inline useful.
These showed up inspecting the assembly for an interrupt handler requiring sub-µs turn-around times, so fairly critical for that application.