### PR TITLE
Be more careful computing the size of an array Cluster.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use register iterator from `svd-parser`
 - rm unneeded `core::convert::` prefix on `From`
 
+### Fixed
+
+- Padding has been corrected for SVD files containing nested array clusters.
+
+  This showed up on Cypress PSOC and Traveo II CPUs.
+
 ## [v0.18.0] - 2021-04-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,13 +11,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - MSP430 API for atomically changing register bits, gated behind the `--nightly` flag
 - New SVD test for `msp430fr2355`
-
-### Added
-
 - Option `-o`(`--output-path`) let you specify output directory path
 
 ### Changed
 
+- `_rererved` fields in `RegisterBlock` now hexidemical usize
 - options can be set now with `svd2rust.toml` config
 - option `ignore_groups` for optional disabling #506
 - [breaking-change] move `const_generic` from features to options

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -478,11 +478,20 @@ fn register_or_cluster_block(
         let is_region_a_union = region.is_union();
 
         for reg_block_field in &region.rbfs {
-            let comment = &format!(
-                "0x{:02x} - {}",
-                reg_block_field.offset,
-                util::escape_brackets(util::respace(&reg_block_field.description).as_ref()),
-            )[..];
+            let comment = if reg_block_field.size > 32 {
+                format!(
+                    "0x{:02x}..0x{:02x} - {}",
+                    reg_block_field.offset,
+                    reg_block_field.offset + reg_block_field.size / 8,
+                    util::escape_brackets(util::respace(&reg_block_field.description).as_ref()),
+                )
+            } else {
+                format!(
+                    "0x{:02x} - {}",
+                    reg_block_field.offset,
+                    util::escape_brackets(util::respace(&reg_block_field.description).as_ref()),
+                )
+            };
 
             if is_region_a_union {
                 let name = &reg_block_field.field.ident;

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -468,7 +468,7 @@ fn register_or_cluster_block(
         let pad = region.offset - last_end;
         if pad != 0 {
             let name = Ident::new(&format!("_reserved{}", i), span);
-            let pad = pad as usize;
+            let pad = util::hex(pad as u64);
             rbfs.extend(quote! {
                 #name : [u8; #pad],
             });
@@ -533,7 +533,7 @@ fn register_or_cluster_block(
                 ),
                 span,
             );
-            let pad = (region.end - region.offset) as usize;
+            let pad = util::hex((region.end - region.offset) as u64);
             rbfs.extend(quote! {
                 #name: [u8; #pad],
             })


### PR DESCRIPTION
`cluster_size_in_bits` was ignoring array information, leading to incorrect padding with nested clusters.
I noticed this as incorrect padding on the three SARs in PASS0 on the Cypress cyt4bb. (The .svd for this requires registration on the Cypress website.)
It also shows up as incorrect padding on the TCPWM0 in the Cypress PSOC6_04 (svd at https://github.com/cypresssemiconductorco/psoc6pdl/blob/master/devices/svd/psoc6_04.svd)

E.g., for the PSOC TCPWM0, the diffs on the generated code from this change are:
```
diff --git a/src/tcpwm0.rs b/src/tcpwm0.rs
index 678d146..7165c46 100644
--- a/src/tcpwm0.rs
+++ b/src/tcpwm0.rs
@@ -3,7 +3,7 @@
 pub struct RegisterBlock {
     #[doc = "0x00 - Group of counters"]
     pub grp0: GRP,
-    _reserved1: [u8; 32640usize],
+    _reserved1: [u8; 31744usize],
     #[doc = "0x8000 - Group of counters"]
     pub grp1: GRP,
 }
```
Eyeballing the GRP, it has 8 * 128byte entries = 1024 bytes, and the correct padding is then 32768 - 1024 = 31744 bytes.