### PR TITLE
add device.x  for riscv targets, and provides __EXTERNAL_INTERRUPTS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - MSP430 API for atomically changing register bits, gated behind the `--nightly` flag
 - New SVD test for `msp430fr2355`
 - Option `-o`(`--output-path`) let you specify output directory path
+- Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
+
 ## [v0.19.0] - 2021-05-26
 
 ### Added
@@ -14,7 +16,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - MSP430 API for atomically changing register bits, gated behind the `--nightly` flag
 - New SVD test for `msp430fr2355`
 - Option `-o`(`--output-path`) let you specify output directory path
-- Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
 
 ### Changed
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -127,11 +127,7 @@ pub fn render(
         }
         Target::RISCV => {
             for name in &names {
-                writeln!(
-                    device_x,
-                    "PROVIDE({} = DefaultExternalInterruptHandler);",
-                    name
-                )?;
+                writeln!(device_x, "PROVIDE({} = DefaultHandler);", name)?;
             }
 
             root.extend(quote! {

--- a/src/main.rs
+++ b/src/main.rs
@@ -160,7 +160,11 @@ fn run() -> Result<()> {
     file.write_all(data.as_ref())
         .expect("Could not write code to lib.rs");
 
-    if target == Target::CortexM || target == Target::Msp430 || target == Target::XtensaLX {
+    if target == Target::CortexM
+        || target == Target::Msp430
+        || target == Target::XtensaLX
+        || target == Target::RISCV
+    {
         writeln!(File::create(path.join("device.x"))?, "{}", device_x)?;
         writeln!(File::create(path.join("build.rs"))?, "{}", build_rs())?;
     }


### PR DESCRIPTION
This PR is a proposal to address #526 . 

`__EXTERNAL_INTERRUPTS` is the symbol used since `__INTERRUPTS` is used by [riscv-rt](https://github.com/rust-embedded/riscv-rt/blob/47ece5f5163a2e38ce5e4685b5d3145713d7954a/src/lib.rs#L505)

I think it fits because the peripheral interrupts are supposed to be pending through the external interrupt. 

This provides hals with information to manage interrupt request. either through a PLIC or trough the vectored interrupt when that is implemented (in [riscv-rt](https://github.com/rust-embedded/riscv-rt/issues/1) i suppose).

Remarks welcome