### PR TITLE
Allow multiple level of deriveFrom peripherals.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
+- Re-export base's module for derived peripherals
 
 ## [v0.19.0] - 2021-05-26
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -91,6 +91,11 @@ pub fn render(
     // Derived peripherals may not require re-implementation, and will instead
     // use a single definition of the non-derived version.
     if derive_regs {
+        // re-export the base module to allow deriveFrom this one
+        out.extend(quote! {
+            #[doc = #description]
+            pub use #base as #name_sc;
+        });
         return Ok(out);
     }
 


### PR DESCRIPTION
Adds an alias to the base module to allow for multiple level of `deriveFrom`.