### PR TITLE
Put padding for cluster-arrays inside each individual array element,

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
 - Re-export base's module for derived peripherals
+- More SVD arrays are now converted to rust arrays, instead of as a list of numbered fields
 
 ## [v0.19.0] - 2021-05-26
 


### PR DESCRIPTION
Currently, some SVD arrays get emitted as a sequence of numbered fields, instead of as a single rust array, due to padding between elements.

This change moves the padding into the array elements, allowing the SVD array to be emitted as a rust array. This makes the generated API more consistent and easier to use. (The downside is that the API changes are not backward compatible.)

Cypress PSOC and Traveo processors appear to be particularly effected with this, it looks like many others get no change. I made a git repo show the changes for three processors at https://github.com/rcls/svd2rust-example/commit/08798fcad125ebe1d4751fee79917c0635cac24a