### PR TITLE
Remove unnecessary borrows.

### DIFF
--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -696,7 +696,7 @@ fn expand_cluster(
 
             if array_convertible {
                 cluster_expanded.push(RegisterBlockField {
-                    field: convert_svd_cluster(&cluster, name)?,
+                    field: convert_svd_cluster(cluster, name)?,
                     description: info.description.as_ref().unwrap_or(&info.name).into(),
                     offset: info.address_offset,
                     size: cluster_size * array_info.dim,
@@ -754,7 +754,7 @@ fn expand_register(
 
             if array_convertible {
                 register_expanded.push(RegisterBlockField {
-                    field: convert_svd_register(&register, name, config.ignore_groups)?,
+                    field: convert_svd_register(register, name, config.ignore_groups)?,
                     description: info.description.clone().unwrap_or_default(),
                     offset: info.address_offset,
                     size: register_size * array_info.dim,
@@ -987,7 +987,7 @@ fn name_to_ty_str<'a, 'b>(name: &'a str, ns: Option<&'b str>) -> Cow<'a, str> {
 }
 
 fn name_to_ty(name: &str, ns: Option<&str>) -> Result<syn::Type, syn::Error> {
-    let ident = name_to_ty_str(&name, ns);
+    let ident = name_to_ty_str(name, ns);
     Ok(syn::Type::Path(parse_str::<syn::TypePath>(&ident)?))
 }
 

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -404,12 +404,12 @@ pub fn fields(
                         }
                     };
                     let name_sc_n = Ident::new(
-                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), &suffix),
+                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), suffix),
                         Span::call_site(),
                     );
                     let doc = util::replace_suffix(
                         &description_with_bits(&description, sub_offset, width),
-                        &suffix,
+                        suffix,
                     );
                     r_impl_items.extend(quote! {
                         #[doc = #doc]
@@ -587,7 +587,7 @@ pub fn fields(
                         let pc = util::replace_suffix(base.field, "");
                         let pc = pc.to_sanitized_upper_case();
                         let base_pc_w = Ident::new(&(pc + "_AW"), span);
-                        derive_from_base(mod_items, &base, &name_pc_aw, &base_pc_w, &description)
+                        derive_from_base(mod_items, &base, name_pc_aw, &base_pc_w, &description)
                     } else if variants.is_empty() {
                         add_with_no_variants(mod_items, name_pc_aw, &fty, &description, rv);
                     } else {
@@ -761,12 +761,12 @@ pub fn fields(
                 for (i, suffix) in (0..*dim).zip(suffixes.iter()) {
                     let sub_offset = offset + (i as u64) * (*increment as u64);
                     let name_sc_n = Ident::new(
-                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), &suffix),
+                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), suffix),
                         Span::call_site(),
                     );
                     let doc = util::replace_suffix(
                         &description_with_bits(&description, sub_offset, width),
-                        &suffix,
+                        suffix,
                     );
                     let sub_offset = util::unsuffixed(sub_offset as u64);
                     if !config.const_generic {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -535,7 +535,7 @@ pub fn generate(xml: &str, config: &Config) -> Result<Generation> {
     let device = svd::parse(xml)?;
     let mut device_x = String::new();
     let items =
-        generate::device::render(&device, &config, &mut device_x).or(Err(SvdError::Render))?;
+        generate::device::render(&device, config, &mut device_x).or(Err(SvdError::Render))?;
 
     let mut lib_rs = String::new();
     writeln!(


### PR DESCRIPTION
Running `cargo +nightly clippy`, I noticed a few complaints about unnecessary borrows.  Remove those. Clippy now has no complaints either on stable or nightly.

Still builds with stable, and running on a few SVD files, no changes (except for version info).