### PR TITLE
Don't use a mask when not needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   elements.  An `ArrayProxy` wrapper is used when a Rust built-in array does not
   match the cluster layout.  Requires the `--const_generic` command line option.
 - Bumped `xtensa-lx` and add `xtensa_lx::interrupt::InterruptNumber` implementation.
+- Don't use a mask when the width of the mask is the same as the width of the parent register.
 
 ## [v0.19.0] - 2021-05-26
 


### PR DESCRIPTION
When the mask has the same size as the parent register of a field, then
a mask is not required. This removes the clippy warnings/errors where
for example an operation of inverting a mask results in zero

```
error: this operation will always return zero. This is likely not the intended outcome
   |
61 |         self.w.bits = (self.w.bits & !0xffff_ffff) | (value as u32 & 0xffff_ffff);
   |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
```

or when the operation of using a mask is ineffective.

```
warning: the operation is ineffective. Consider reducing it to `value as u32`
   |
61 |         self.w.bits = (self.w.bits & !0xffff_ffff) | (value as u32 & 0xffff_ffff);
   |                                                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
```