### PR TITLE
add `#[inline(always)]` to register field reader constructors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Missing `inline` on field reader constructors
 - Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
 - Re-export base's module for derived peripherals
+
+### Changed
+
 - More Cluster arrays are now emitted as an array rather than a list of
   elements.  An `ArrayProxy` wrapper is used when a Rust built-in array does not
   match the cluster layout.  Requires the `--const_generic` command line option.

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -541,6 +541,7 @@ pub fn fields(
                         pub struct #name_pc_r(crate::FieldReader<#fty, #name_pc_a>);
 
                         impl #name_pc_r {
+                            #[inline(always)]
                             pub(crate) fn new(bits: #fty) -> Self {
                                 #name_pc_r(crate::FieldReader::new(bits))
                             }
@@ -563,6 +564,7 @@ pub fn fields(
                     pub struct #name_pc_r(crate::FieldReader<#fty, #fty>);
 
                     impl #name_pc_r {
+                        #[inline(always)]
                         pub(crate) fn new(bits: #fty) -> Self {
                             #name_pc_r(crate::FieldReader::new(bits))
                         }


### PR DESCRIPTION
Currently field modifications aren't fully inlined