### PR TITLE
Better error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   match the cluster layout.  Requires the `--const_generic` command line option.
 - Bumped `xtensa-lx` and add `xtensa_lx::interrupt::InterruptNumber` implementation.
 - Don't use a mask when the width of the mask is the same as the width of the parent register.
+- Improved error handling
 
 ## [v0.19.0] - 2021-05-26
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -1,12 +1,13 @@
 use crate::svd::Device;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
+
 use std::fs::File;
 use std::io::Write;
 
 use crate::util::{self, Config, ToSanitizedUpperCase};
 use crate::Target;
-use anyhow::Result;
+use anyhow::{Context, Result};
 
 use crate::generate::{interrupt, peripheral};
 
@@ -191,12 +192,27 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             continue;
         }
 
-        out.extend(peripheral::render(
-            p,
-            &d.peripherals,
-            &d.default_register_properties,
-            config,
-        )?);
+        match peripheral::render(p, &d.peripherals, &d.default_register_properties, config) {
+            Ok(periph) => out.extend(periph),
+            Err(e) => {
+                let descrip = p.description.as_deref().unwrap_or("No description");
+                let group_name = p.group_name.as_deref().unwrap_or("No group name");
+                let mut context_string = format!(
+                    "Rendering error at peripheral\nName: {}\nDescription: {}\nGroup: {}",
+                    p.name, descrip, group_name
+                );
+                if p.derived_from.is_some() {
+                    context_string = format!(
+                        "{}\nDerived from: {}",
+                        context_string,
+                        p.derived_from.as_deref().unwrap()
+                    );
+                }
+                let mut e = Err(e);
+                e = e.with_context(|| context_string);
+                return e;
+            }
+        };
 
         if p.registers
             .as_ref()

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,6 @@
 #![recursion_limit = "128"]
 
-use log::error;
+use log::{error, info};
 use std::path::PathBuf;
 use svd_parser::svd;
 
@@ -164,10 +164,15 @@ fn run() -> Result<()> {
         svd::ValidateLevel::Weak
     };
 
-    let device = svd_parser::parse_with_config(xml, &parser_config)?;
+    info!("Parsing device from SVD file");
+    let device = svd_parser::parse_with_config(xml, &parser_config)
+        .with_context(|| "Error parsing SVD file".to_string())?;
 
     let mut device_x = String::new();
-    let items = generate::device::render(&device, &config, &mut device_x)?;
+    info!("Rendering device");
+    let items = generate::device::render(&device, &config, &mut device_x)
+        .with_context(|| "Error rendering device")?;
+
     let filename = if make_mod { "mod.rs" } else { "lib.rs" };
     let mut file = File::create(path.join(filename)).expect("Couldn't create output file");
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,7 +6,7 @@ use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::path::PathBuf;
 
-use anyhow::{anyhow, bail, Result};
+use anyhow::{anyhow, bail, Context, Result};
 
 pub const BITS_PER_BYTE: u32 = 8;
 
@@ -368,6 +368,22 @@ pub fn build_rs() -> TokenStream {
             println!("cargo:rerun-if-changed=build.rs");
         }
     }
+}
+
+pub fn handle_reg_error<T>(msg: &str, reg: &Register, res: Result<T>) -> Result<T> {
+    let reg_name = &reg.name;
+    let descrip = reg.description.as_deref().unwrap_or("No description");
+    handle_erc_error(msg, reg_name, descrip, res)
+}
+
+pub fn handle_cluster_error<T>(msg: &str, cluster: &Cluster, res: Result<T>) -> Result<T> {
+    let cluster_name = &cluster.name;
+    let descrip = cluster.description.as_deref().unwrap_or("No description");
+    handle_erc_error(msg, cluster_name, descrip, res)
+}
+
+fn handle_erc_error<T>(msg: &str, name: &str, descrip: &str, res: Result<T>) -> Result<T> {
+    res.with_context(|| format!("{}\nName: {}\nDescription: {}", msg, name, descrip))
 }
 
 pub trait FullName {


### PR DESCRIPTION
Just a small attempt to make `svd2rust` print more useful information if something goes wrong in the TokenStream generation, or in general

- More debug output in case something goes wrong in the TokenStream generation
- Some info output in the main

I like how the `svd` XML parser handles errors by passing an Error Enum with a node ID up which can be used by one central error handler to print diagnostic information. I don't think it can be done like that here, so I simply print out some locally available information (peripheral name, register name etc.) as the error is propagated