### PR TITLE
Possible fix for derived register arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bumped `xtensa-lx` and add `xtensa_lx::interrupt::InterruptNumber` implementation.
 - Don't use a mask when the width of the mask is the same as the width of the parent register.
 
+### Fixed
+
+- When expanding register arrays which were derived from a single
+  register, a single register was returned even though the derived type
+  was an array. This has been fixed by checking the derived and ancestor
+  type now
+
 ## [v0.19.0] - 2021-05-26
 
 ### Added

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -133,47 +133,34 @@ pub fn render(
                 };
 
                 match (erc, ancestor) {
-                    (
-                        RegisterCluster::Register(reg),
-                        RegisterCluster::Register(other_reg)
-                    ) => {
+                    (RegisterCluster::Register(reg), RegisterCluster::Register(other_reg)) => {
                         // Check all possible combinations for derived and own type
                         match (reg, other_reg) {
-                            (
-                                Register::Single(_),
-                                Register::Single(ref other_info)
-                            ) => {
+                            (Register::Single(_), Register::Single(ref other_info)) => {
                                 Some(RegisterCluster::Register(Register::Single(
-                                    reg.derive_from(other_info)
+                                    reg.derive_from(other_info),
                                 )))
                             }
                             (
                                 Register::Single(_),
-                                Register::Array(ref other_info, ref other_dim)
-                            ) => {
+                                Register::Array(ref other_info, ref other_dim),
+                            ) => Some(RegisterCluster::Register(Register::Array(
+                                reg.derive_from(other_info),
+                                other_dim.clone(),
+                            ))),
+                            (Register::Array(_, ref dim), Register::Single(ref other_info)) => {
                                 Some(RegisterCluster::Register(Register::Array(
                                     reg.derive_from(other_info),
-                                    other_dim.clone()
-                                )))
-                            }
-                            (
-                                Register::Array(_, ref dim),
-                                Register::Single(ref other_info)
-                            ) => {
-                                Some(RegisterCluster::Register(Register::Array(
-                                    reg.derive_from(other_info),
-                                    dim.clone()
+                                    dim.clone(),
                                 )))
                             }
                             (
                                 Register::Array(_, _),
-                                Register::Array(ref other_info, ref other_dim)
-                            ) => {
-                                Some(RegisterCluster::Register(Register::Array(
-                                    reg.derive_from(other_info),
-                                    other_dim.clone()
-                                )))
-                            }
+                                Register::Array(ref other_info, ref other_dim),
+                            ) => Some(RegisterCluster::Register(Register::Array(
+                                reg.derive_from(other_info),
+                                other_dim.clone(),
+                            ))),
                         }
                     }
                     (

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -133,17 +133,47 @@ pub fn render(
                 };
 
                 match (erc, ancestor) {
-                    (RegisterCluster::Register(reg), RegisterCluster::Register(other_reg)) => {
-                        match other_reg {
-                            Register::Array(ref info, ref array_info) => {
-                                Some(RegisterCluster::Register(Register::Array(
-                                    reg.derive_from(info),
-                                    array_info.clone(),
+                    (
+                        RegisterCluster::Register(reg),
+                        RegisterCluster::Register(other_reg)
+                    ) => {
+                        // Check all possible combinations for derived and own type
+                        match (reg, other_reg) {
+                            (
+                                Register::Single(_),
+                                Register::Single(ref other_info)
+                            ) => {
+                                Some(RegisterCluster::Register(Register::Single(
+                                    reg.derive_from(other_info)
                                 )))
                             }
-                            Register::Single(ref info) => Some(RegisterCluster::Register(
-                                Register::Single(reg.derive_from(info)),
-                            )),
+                            (
+                                Register::Single(_),
+                                Register::Array(ref other_info, ref other_dim)
+                            ) => {
+                                Some(RegisterCluster::Register(Register::Array(
+                                    reg.derive_from(other_info),
+                                    other_dim.clone()
+                                )))
+                            }
+                            (
+                                Register::Array(_, ref dim),
+                                Register::Single(ref other_info)
+                            ) => {
+                                Some(RegisterCluster::Register(Register::Array(
+                                    reg.derive_from(other_info),
+                                    dim.clone()
+                                )))
+                            }
+                            (
+                                Register::Array(_, _),
+                                Register::Array(ref other_info, ref other_dim)
+                            ) => {
+                                Some(RegisterCluster::Register(Register::Array(
+                                    reg.derive_from(other_info),
+                                    other_dim.clone()
+                                )))
+                            }
                         }
                     }
                     (


### PR DESCRIPTION
Possibly fixes #361 . 
I haven't tried the regression tool yet to ensure nothing went wrong, but I was able to generate a PAC for the VA108XX family of devices with these adaptions without any `syn` errors.

The issue was that the SVD file had a register array which was derived from a single register. In the previous implementation, only the other register is checked which meant that a single array was generated even though the derived one is still an array