### PR TITLE
Added debug and trace output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Missing `inline` on field reader constructors
 - Support for device.x generation for riscv targets and `__EXTERNAL_INTERRUPTS` vector table
 - Re-export base's module for derived peripherals
+- More debug and trace output to visualize program control flow
 
 ### Changed
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -2,6 +2,7 @@ use crate::svd::Device;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 
+use log::debug;
 use std::fs::File;
 use std::io::Write;
 
@@ -184,6 +185,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         });
     }
 
+    debug!("Rendering interrupts");
     out.extend(interrupt::render(config.target, &d.peripherals, device_x)?);
 
     for p in &d.peripherals {
@@ -192,6 +194,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             continue;
         }
 
+        debug!("Rendering peripheral {}", p.name);
         match peripheral::render(p, &d.peripherals, &d.default_register_properties, config) {
             Ok(periph) => out.extend(periph),
             Err(e) => {

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -6,7 +6,7 @@ use crate::svd::{
     Cluster, ClusterInfo, DeriveFrom, DimElement, Peripheral, Register, RegisterCluster,
     RegisterProperties,
 };
-use log::warn;
+use log::{debug, trace, warn};
 use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
 use quote::{quote, ToTokens};
 use syn::{parse_str, Token};
@@ -168,16 +168,24 @@ pub fn render(
     let defaults = p.default_register_properties.derive_from(defaults);
 
     // Push any register or cluster blocks into the output
+    debug!(
+        "Pushing {} register or cluster blocks into output",
+        ercs.len()
+    );
     let mut mod_items = TokenStream::new();
     mod_items.extend(register_or_cluster_block(&ercs, &defaults, None, config)?);
 
+    debug!("Pushing cluster information into output");
     // Push all cluster related information into the peripheral module
     for c in &clusters {
+        trace!("Cluster: {}", c.name);
         mod_items.extend(cluster_block(c, &defaults, p, all_peripherals, config)?);
     }
 
+    debug!("Pushing register information into output");
     // Push all register related information into the peripheral module
     for reg in registers {
+        trace!("Register: {}", reg.name);
         match register::render(reg, registers, p, all_peripherals, &defaults, config) {
             Ok(rendered_reg) => mod_items.extend(rendered_reg),
             Err(e) => {
@@ -579,11 +587,15 @@ fn expand(
 ) -> Result<Vec<RegisterBlockField>> {
     let mut ercs_expanded = vec![];
 
+    debug!("Expanding registers or clusters into Register Block Fields");
     for erc in ercs {
         match &erc {
             RegisterCluster::Register(register) => {
                 match expand_register(register, defs, name, config) {
-                    Ok(expanded_reg) => ercs_expanded.extend(expanded_reg),
+                    Ok(expanded_reg) => {
+                        trace!("Register: {}", register.name);
+                        ercs_expanded.extend(expanded_reg);
+                    }
                     Err(e) => {
                         let res = Err(e);
                         return handle_reg_error("Error expanding register", register, res);
@@ -592,7 +604,10 @@ fn expand(
             }
             RegisterCluster::Cluster(cluster) => {
                 match expand_cluster(cluster, defs, name, config) {
-                    Ok(expanded_cluster) => ercs_expanded.extend(expanded_cluster),
+                    Ok(expanded_cluster) => {
+                        trace!("Cluster: {}", cluster.name);
+                        ercs_expanded.extend(expanded_cluster);
+                    }
                     Err(e) => {
                         let res = Err(e);
                         return handle_cluster_error(


### PR DESCRIPTION
The application already has log levels and these additional logs will be disabled by default. They can be helpful when debugging something or tracing where an error/warning happens