### PR TITLE
Fixes in multi line description generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Bug with `use_mask`
 - Correct derive for register (cluster) array (needs `svd-rs` 0.11.2) 
+- New line separators are now rendered in enumerated values
+- Multi line field descriptions are now rendered correctly in write and read registers
 
 ### Added
 


### PR DESCRIPTION
This pull request contains two fixes:
1. New line separators are now rendered in enumerated values. 
2. Multi line field descriptions are now rendered correctly in write and read registers.

This issue happened because the original code accidentally unescaped and respaced twice in field parse proccess. It uses escaped description [L292](https://github.com/rust-embedded/svd2rust/compare/master...luojia65:fix-new-line?expand=1#diff-ff493acd6701940416e9725ce824c71d3039b5c56efc3721cf15d1688b3f7deaL292) as input, but in `desctiption_with_bits` function later [L1001](https://github.com/rust-embedded/svd2rust/compare/master...luojia65:fix-new-line?expand=1#diff-ff493acd6701940416e9725ce824c71d3039b5c56efc3721cf15d1688b3f7deaL1001 ) it unescaped again, resulting in loss of new line separators `\n`.

Before:

![图片](https://user-images.githubusercontent.com/40385009/141669374-2d6246c6-d6a0-4e9f-b107-5fc2b53c1498.png)

After:

![图片](https://user-images.githubusercontent.com/40385009/141669385-8850d267-7879-4600-a5d1-d29cb0d6ab20.png)