### PR TITLE
Generate safe bits writers when possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bumped `xtensa-lx` and add `xtensa_lx::interrupt::InterruptNumber` implementation.
 - Don't use a mask when the width of the mask is the same as the width of the parent register.
 - Improved error handling
+- Registers with single fields that span the entire register now generate safe `bits` writers.
 
 ## [v0.19.0] - 2021-05-26
 


### PR DESCRIPTION
The 'bits' method of register writers can be safe if:
* there is a single field that covers the entire register
* that field can represent all values