### PR TITLE
fix: Replace suffix before converting to snake case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Replace suffix in fields' name before converting to snake case when generating methods #563
+
 ## [v0.20.0] - 2021-12-07
 
 ### Fixed

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -440,7 +440,7 @@ pub fn fields(
                         }
                     };
                     let name_sc_n = Ident::new(
-                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), suffix),
+                        &util::replace_suffix(&f.name, suffix).to_sanitized_snake_case(),
                         Span::call_site(),
                     );
                     let doc = util::replace_suffix(
@@ -805,7 +805,7 @@ pub fn fields(
                 for (i, suffix) in (0..*dim).zip(suffixes.iter()) {
                     let sub_offset = offset + (i as u64) * (*increment as u64);
                     let name_sc_n = Ident::new(
-                        &util::replace_suffix(&f.name.to_sanitized_snake_case(), suffix),
+                        &util::replace_suffix(&f.name, suffix).to_sanitized_snake_case(),
                         Span::call_site(),
                     );
                     let doc = util::replace_suffix(


### PR DESCRIPTION
## Abstract

In #563, we noticed that converting fields' names to snake cases before replacing the suffix caused the generated methods not to satisfy the snake case. This PR fixes this issue.

## Change

Use `util::replace_suffix(&f.name, suffix).to_sanitized_snake_case()` instead of `util::replace_suffix(&f.name.to_sanitized_snake_case(), suffix)` when generating methods of fields.