### PR TITLE
add re-export of mips_rt::interrupt for MIPS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Parenthesizing `#offset_calc` to avoid clippy's warning of operator precedence
 - Replace suffix in fields' name before converting to snake case when generating methods #563
 
+### Changed
+
+- MIPS API now re-exports `mips_rt::interrupt` when the `rt` feature is enabled
+
 ## [v0.20.0] - 2021-12-07
 
 ### Fixed

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -139,6 +139,13 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         });
     }
 
+    if config.target == Target::Mips {
+        out.extend(quote! {
+            #[cfg(feature = "rt")]
+            pub use mips_rt::interrupt;
+        });
+    }
+
     let generic_file = std::str::from_utf8(include_bytes!("generic.rs"))?;
     if config.generic_mod {
         let mut file = File::create(config.output_dir.join("generic.rs"))?;


### PR DESCRIPTION
A small change to the MIPS/PIC32 target so that the `#[interrupt]` attribute macro can be used.