### PR TITLE
disable the interrupt macro for MIPS as well

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `svd-parser` v0.13.1
 - Replace suffix in fields' name before converting to snake case when generating methods #563
 - MIPS API now re-exports `mips_rt::interrupt` when the `rt` feature is enabled
+  but does not generate the `interrupt` macro anymore
 
 ### Fixed
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -277,7 +277,11 @@ pub fn render(
             _ => "C",
         };
 
-        if target != Target::CortexM && target != Target::Msp430 && target != Target::XtensaLX {
+        if target != Target::CortexM
+            && target != Target::Msp430
+            && target != Target::XtensaLX
+            && target != Target::Mips
+        {
             mod_items.extend(quote! {
                 #[cfg(feature = "rt")]
                 #[macro_export]


### PR DESCRIPTION
r? @burrbull

Yet another small MIPS fix in addition to yesterday's change. Sorry for submitting two separate PR instead of a single one. I did not realize that the interrupt macro can cause name clashes when including multiple device support modules into a single crate. I discovered this problem when trying to build the docs.