### PR TITLE
Add --mark_range flag

### DIFF
--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -7,6 +7,7 @@ use core::u64;
 use log::warn;
 use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
 use quote::{quote, ToTokens};
+use std::collections::HashSet;
 
 use crate::util::{self, Config, ToSanitizedSnakeCase, ToSanitizedUpperCase, U32Ext};
 use anyhow::{anyhow, Result};
@@ -48,6 +49,7 @@ pub fn render(
     let mut mod_items = TokenStream::new();
     let mut r_impl_items = TokenStream::new();
     let mut w_impl_items = TokenStream::new();
+    let mut marker_impl_items = TokenStream::new();
     let mut methods = vec![];
 
     let can_read = access.can_read();
@@ -266,6 +268,22 @@ pub fn render(
             }
         });
     }
+
+    let address = peripheral.base_address + register.address_offset as u64;
+    let markers: HashSet<_> = config
+        .mark_ranges
+        .iter()
+        .filter(|m| m.start <= address && address < m.end)
+        .map(|m| m.name.as_str())
+        .collect();
+    for marker in markers {
+        let name = Ident::new(marker, span);
+        marker_impl_items.extend(quote! {
+            impl crate::markers::#name for #name_uc_spec {}
+        });
+    }
+
+    mod_items.extend(marker_impl_items);
 
     out.extend(quote! {
         #[doc = #description]

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,4 +1,4 @@
-use std::borrow::Cow;
+use std::{borrow::Cow, num::ParseIntError};
 
 use crate::svd::{
     Access, Cluster, Field, Register, RegisterCluster, RegisterInfo, RegisterProperties,
@@ -28,6 +28,7 @@ pub struct Config {
     pub strict: bool,
     pub output_dir: PathBuf,
     pub source_type: SourceType,
+    pub mark_ranges: Vec<MarkRange>,
 }
 
 impl Default for Config {
@@ -43,8 +44,17 @@ impl Default for Config {
             strict: false,
             output_dir: PathBuf::from("."),
             source_type: SourceType::default(),
+            mark_ranges: Vec::new(),
         }
     }
+}
+
+#[derive(Clone, PartialEq, Debug)]
+
+pub struct MarkRange {
+    pub name: String,
+    pub start: u64,
+    pub end: u64,
 }
 
 #[allow(clippy::upper_case_acronyms)]
@@ -433,5 +443,13 @@ impl FullName for RegisterInfo {
             Some(group) if !ignore_group => format!("{}_{}", group, self.name).into(),
             _ => self.name.as_str().into(),
         }
+    }
+}
+
+pub fn parse_address(addr: &str) -> Result<u64, ParseIntError> {
+    if addr.starts_with("0x") {
+        u64::from_str_radix(&addr[2..], 16)
+    } else {
+        u64::from_str_radix(addr, 10)
     }
 }


### PR DESCRIPTION
This flag allows implementing a marker trait for registers in specific memory addresses. These can then be used to implement methods on registers. One such example is providing atomic access to only some of the registers directly in the PAC. Currently this is done in HAL, but this loses the ability to use writer proxies. It is also finicky to use raw register addresses. Moreover this allows keeping atomic and non-atomic usage in HAL more similar.

For an example on how to use this, see my [fork of rp2040-pac](https://github.com/henkkuli/rp2040-pac/commit/f701d72ca010b7e5451986718d89ee296230ebda). The most interesting changes regarding the use reside in
- [`generic_extension.rs`](https://github.com/henkkuli/rp2040-pac/commit/f701d72ca010b7e5451986718d89ee296230ebda#diff-5d2c6f640d0464d137f154be92f25979060a6c6c77d398a153fa39adaa79e944)
- [`update.sh`](https://github.com/henkkuli/rp2040-pac/commit/f701d72ca010b7e5451986718d89ee296230ebda#diff-e14594f6bb9b29ac0146c04e78ae33e8e92f2f00709fefab97359dea31b94d11)

Even though I have an example only for the RP2040, I believe that other architectures and devices could also benefit from this. For example on SMT32 MCUs this could be used to implement a nicer API for bit-banding.

Addresses #535 