### PR TITLE
Bring documentation on MSP430 up to date.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Bring documentation on how to generate MSP430 PACs up to date (in line with
+  [msp430_svd](https://github.com/pftbest/msp430_svd)).
+
 ## [v0.21.0] - 2022-01-17
 
 ### Added
@@ -34,7 +39,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Bug with `use_mask`
-- Correct derive for register (cluster) array (needs `svd-rs` 0.11.2) 
+- Correct derive for register (cluster) array (needs `svd-rs` 0.11.2)
 - New line separators are now rendered in enumerated values
 - Multi line field descriptions are now rendered correctly in write and read registers
 
@@ -67,7 +72,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
-- `\n` in descriptions for multiline 
+- `\n` in descriptions for multiline
 - `_reserved` fields in `RegisterBlock` now hexidemical usize
 - options can be set now with `svd2rust.toml` config
 - option `ignore_groups` for optional disabling #506
@@ -120,7 +125,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - with feature "const-generic" generate const generic variant of
   "field array" structure in addition to structure
-  that contain offset (requires rust 1.51) 
+  that contain offset (requires rust 1.51)
 
 - move interrupt generation after generic file
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -507,10 +507,10 @@ main() {
         # test other targets (architectures)
         OTHER)
             echo '[dependencies.msp430]' >> $td/Cargo.toml
-            echo 'version = "0.2.2"' >> $td/Cargo.toml
+            echo 'version = "0.3.0"' >> $td/Cargo.toml
 
             # Test MSP430
-            test_svd_for_target msp430 https://raw.githubusercontent.com/pftbest/msp430g2553/v0.1.3-svd/msp430g2553.svd
+            test_svd_for_target msp430 https://raw.githubusercontent.com/pftbest/msp430g2553/v0.3.0-svd/msp430g2553.svd
         ;;
 
         # Community-provided RISC-V SVDs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,30 +99,32 @@
 //!
 //! $ xmllint -format out.svd > msp430g2553.svd
 //!
-//! $ svd2rust --target=msp430 -i msp430g2553.svd
+//! $ svd2rust -g --target=msp430 -i msp430g2553.svd
 //!
 //! $ rm -rf src
 //!
 //! $ form -i lib.rs -o src/ && rm lib.rs
 //!
+//! $ mv generic.rs src/
+//!
 //! $ cargo fmt
 //! ```
 //!
 //! The resulting crate must provide opt-in "rt" feature and depend on these crates: `msp430`
-//! v0.2.x, `msp430-rt` v0.2.x, and `vcell` v0.1.x. If the `--nightly` flag is provided to
-//! `svd2rust`, then `msp430-atomic` v0.1.2 is also needed. Furthermore the "device" feature of
+//! v0.3.x, `msp430-rt` v0.3.x, and `vcell` v0.1.x. If the `--nightly` flag is provided to
+//! `svd2rust`, then `msp430-atomic` v0.1.4 is also needed. Furthermore the "device" feature of
 //! `msp430-rt` must be enabled when the "rt" feature is enabled. The `Cargo.toml` of the device
 //! crate will look like this:
 //!
 //! ``` toml
 //! [dependencies]
-//! msp430 = "0.2.0"
+//! msp430 = "0.3.0"
 //! vcell = "0.1.0"
-//! msp430-atomic = "0.1.2" # Only when using the --nightly flag
+//! msp430-atomic = "0.1.4" # Only when using the --nightly flag
 //!
 //! [dependencies.msp430-rt]
 //! optional = true
-//! version = "0.2.0"
+//! version = "0.3.0"
 //!
 //! [features]
 //! rt = ["msp430-rt/device"]


### PR DESCRIPTION
Crate versions must be `0.3.0` or higher now; minor version `0.2.0` and below is unsupported due to (among other things) bumping to bare-metal `1.0.0` and [using](https://github.com/rust-lang/rust/pull/93219) Rust inline assembly to implement useful operations.