### PR TITLE
Use the official Espressif SVDs for testing, check additional chips

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   If their indices don't start from 0 add accessors with right names.
 - Bring documentation on how to generate MSP430 PACs up to date (in line with
   [msp430_svd](https://github.com/pftbest/msp430_svd)).
+- Use the official SVDs from Espressif for CI and `rust-regress` tests, and
+  additionally test the ESP32-C3, ESP32-S2, and ESP32-S3.
 
 ## [v0.21.0] - 2022-01-17
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -608,15 +608,25 @@ main() {
             echo '[dependencies.bare-metal]' >> $td/Cargo.toml
             echo 'version = "1.0.0"' >> $td/Cargo.toml
 
+            echo '[dependencies.riscv]' >> $td/Cargo.toml
+            echo 'version = "0.6.0"' >> $td/Cargo.toml
+
+            echo '[dependencies.riscv-rt]' >> $td/Cargo.toml
+            echo 'version = "0.8.0"' >> $td/Cargo.toml
+
             echo '[dependencies.xtensa-lx]' >> $td/Cargo.toml
             echo 'version = "0.6.0"' >> $td/Cargo.toml
             echo 'features = ["esp32"]' >> $td/Cargo.toml
 
             echo '[dependencies.xtensa-lx-rt]' >> $td/Cargo.toml
-            echo 'version = "0.8.0"' >> $td/Cargo.toml
+            echo 'version = "0.9.0"' >> $td/Cargo.toml
             echo 'features = ["esp32"]' >> $td/Cargo.toml
 
-            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/esp-rs/esp32/master/svd/esp32.svd
+            test_svd_for_target riscv https://raw.githubusercontent.com/espressif/svd/main/svd/esp32c3.svd
+
+            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/espressif/svd/main/svd/esp32.svd
+            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/espressif/svd/main/svd/esp32s2.svd
+            test_svd_for_target xtensa-lx https://raw.githubusercontent.com/espressif/svd/main/svd/esp32s3.svd
         ;;
 
     esac

--- a/ci/svd2rust-regress/src/svd_test.rs
+++ b/ci/svd2rust-regress/src/svd_test.rs
@@ -10,10 +10,11 @@ const CRATES_MSP430: &[&str] = &["msp430 = \"0.2.2\"", "msp430-rt = \"0.2.0\""];
 const CRATES_MSP430_NIGHTLY: &[&str] = &["msp430-atomic = \"0.1.2\""];
 const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.7.0\"", "cortex-m-rt = \"0.6.13\""];
 const CRATES_RISCV: &[&str] = &["riscv = \"0.5.0\"", "riscv-rt = \"0.6.0\""];
-const CRATES_XTENSALX6: &[&str] = &["xtensa-lx6-rt = \"0.2.0\"", "xtensa-lx6 = \"0.1.0\""];
+const CRATES_XTENSALX: &[&str] = &["xtensa-lx-rt = \"0.9.0\"", "xtensa-lx = \"0.6.0\""];
 const CRATES_MIPS: &[&str] = &["mips-mcu = \"0.1.0\""];
 const PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];
 const FEATURES_ALL: &[&str] = &["[features]"];
+const FEATURES_XTENSALX: &[&str] = &["default = [\"xtensa-lx/esp32\", \"xtensa-lx-rt/esp32\"]"];
 
 fn path_helper(input: &[&str]) -> PathBuf {
     input.iter().collect()
@@ -133,7 +134,7 @@ pub fn test(
             RiscV => CRATES_RISCV.iter(),
             Mips => CRATES_MIPS.iter(),
             Msp430 => CRATES_MSP430.iter(),
-            XtensaLX => CRATES_XTENSALX6.iter(),
+            XtensaLX => CRATES_XTENSALX.iter(),
         })
         .chain(if nightly {
             match &t.arch {
@@ -144,7 +145,11 @@ pub fn test(
             [].iter()
         })
         .chain(PROFILE_ALL.iter())
-        .chain(FEATURES_ALL.iter());
+        .chain(FEATURES_ALL.iter())
+        .chain(match &t.arch {
+            XtensaLX => FEATURES_XTENSALX.iter(),
+            _ => [].iter(),
+        });
 
     for c in crates {
         writeln!(file, "{}", c).chain_err(|| "Failed to append to file!")?;

--- a/ci/svd2rust-regress/src/tests.rs
+++ b/ci/svd2rust-regress/src/tests.rs
@@ -4245,7 +4245,37 @@ pub const TESTS: &[&TestCase] = &[
         mfgr: Espressif,
         chip: "esp32",
         svd_url: Some(
-            "https://raw.githubusercontent.com/arjanmels/esp32/add-output-svd/svd/esp32.svd",
+            "https://raw.githubusercontent.com/espressif/svd/main/svd/esp32.svd",
+        ),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: XtensaLX,
+        mfgr: Espressif,
+        chip: "esp32s2",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/espressif/svd/main/svd/esp32s2.svd",
+        ),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: XtensaLX,
+        mfgr: Espressif,
+        chip: "esp32s3",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/espressif/svd/main/svd/esp32s3.svd",
+        ),
+        should_pass: true,
+        run_when: Always,
+    },
+    &TestCase {
+        arch: RiscV,
+        mfgr: Espressif,
+        chip: "esp32c3",
+        svd_url: Some(
+            "https://raw.githubusercontent.com/espressif/svd/main/svd/esp32c3.svd",
         ),
         should_pass: true,
         run_when: Always,


### PR DESCRIPTION
The CI and `rust-regress` tests for Espressif devices were quite out of date, so I've updated both to use the official SVDs and the most recent dependencies. In addition to the ESP32 the ESP32-C3/S2/S3 are now all checked.