### PR TITLE
add code generation support of peripheral arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Optional PascalCase for Enum values instead of UPPER_CASE
+- Add code generation support of peripheral arrays.
 
 ## [v0.22.2] - 2022-04-13
 

--- a/src/generate/array_proxy.rs
+++ b/src/generate/array_proxy.rs
@@ -15,14 +15,6 @@ pub struct ArrayProxy<T, const COUNT: usize, const STRIDE: usize> {
 }
 
 impl<T, const C: usize, const S: usize> ArrayProxy<T, C, S> {
-    /// Create a new ArrayProxy.
-    #[inline(always)]
-    #[allow(unused)]
-    pub(crate) fn new() -> Self {
-        Self {
-            _array: marker::PhantomData,
-        }
-    }
     /// Get a reference from an [ArrayProxy] with no bounds checking.
     pub unsafe fn get_ref(&self, index: usize) -> &T {
         let base = self as *const Self as usize;

--- a/src/generate/array_proxy.rs
+++ b/src/generate/array_proxy.rs
@@ -17,6 +17,7 @@ pub struct ArrayProxy<T, const COUNT: usize, const STRIDE: usize> {
 impl<T, const C: usize, const S: usize> ArrayProxy<T, C, S> {
     /// Create a new ArrayProxy.
     #[inline(always)]
+    #[allow(unused)]
     pub(crate) fn new() -> Self {
         Self {
             _array: marker::PhantomData,

--- a/src/generate/array_proxy.rs
+++ b/src/generate/array_proxy.rs
@@ -1,4 +1,3 @@
-
 /// Access an array of `COUNT` items of type `T` with the items `STRIDE` bytes
 /// apart.  This is a zero-sized-type.  No objects of this type are ever
 /// actually created, it is only a convenience for wrapping pointer arithmetic.
@@ -12,10 +11,17 @@ pub struct ArrayProxy<T, const COUNT: usize, const STRIDE: usize> {
     /// As well as providing a PhantomData, this field is non-public, and
     /// therefore ensures that code outside of this module can never create
     /// an ArrayProxy.
-    _array: marker::PhantomData<T>
+    _array: marker::PhantomData<T>,
 }
 
 impl<T, const C: usize, const S: usize> ArrayProxy<T, C, S> {
+    /// Create a new ArrayProxy.
+    #[inline(always)]
+    pub(crate) fn new() -> Self {
+        Self {
+            _array: marker::PhantomData,
+        }
+    }
     /// Get a reference from an [ArrayProxy] with no bounds checking.
     pub unsafe fn get_ref(&self, index: usize) -> &T {
         let base = self as *const Self as usize;
@@ -27,13 +33,14 @@ impl<T, const C: usize, const S: usize> ArrayProxy<T, C, S> {
     pub fn get(&self, index: usize) -> Option<&T> {
         if index < C {
             Some(unsafe { self.get_ref(index) })
-        }
-        else {
+        } else {
             None
         }
     }
     /// Return the number of items.
-    pub fn len(&self) -> usize { C }
+    pub fn len(&self) -> usize {
+        C
+    }
 }
 
 impl<T, const C: usize, const S: usize> core::ops::Index<usize> for ArrayProxy<T, C, S> {

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -249,30 +249,17 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
                 exprs.extend(quote!(#id: #id { _marker: PhantomData },));
             }
             Peripheral::Array(_p, dim_element) => {
-                if config.const_generic {
-                    let p_name = util::name_of(p, config.ignore_groups);
-                    let p = p_name.to_sanitized_upper_case();
-                    let id = Ident::new(&p, Span::call_site());
-                    let dim = dim_element.dim as usize;
-                    let dim_increment = util::hex(dim_element.dim_increment as u64);
-                    fields.extend(quote! {
+                let p_names: Vec<Cow<str>> = names(p, dim_element).map(|n| n.into()).collect();
+                let p = p_names.iter().map(|p| p.to_sanitized_upper_case());
+                let ids_f = p.clone().map(|p| Ident::new(&p, Span::call_site()));
+                let ids_e = ids_f.clone();
+                fields.extend(quote! {
+                    #(
                         #[doc = #p]
-                        pub #id: crate::ArrayProxy<#id, #dim, #dim_increment>,
-                    });
-                    exprs.extend(quote!(#id: crate::ArrayProxy::new(),));
-                } else {
-                    let p_names: Vec<Cow<str>> = names(p, dim_element).map(|n| n.into()).collect();
-                    let p = p_names.iter().map(|p| p.to_sanitized_upper_case());
-                    let ids_f = p.clone().map(|p| Ident::new(&p, Span::call_site()));
-                    let ids_e = ids_f.clone();
-                    fields.extend(quote! {
-                        #(
-                            #[doc = #p]
-                            pub #ids_f: #ids_f,
-                        )*
-                    });
-                    exprs.extend(quote!(#(#ids_e: #ids_e { _marker: PhantomData },)*));
-                }
+                        pub #ids_f: #ids_f,
+                    )*
+                });
+                exprs.extend(quote!(#(#ids_e: #ids_e { _marker: PhantomData },)*));
             }
         }
     }

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -58,7 +58,7 @@ pub fn render(
     };
 
     match p_original {
-        p @ Peripheral::Array(_, dim) if !config.const_generic => {
+        Peripheral::Array(p, dim) if !config.const_generic => {
             let names: Vec<Cow<str>> = names(p, dim).map(|n| n.into()).collect();
             let names_str = names.iter().map(|n| n.to_sanitized_upper_case());
             let names_pc = names_str.clone().map(|n| Ident::new(&n, span));

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -58,7 +58,7 @@ pub fn render(
     };
 
     match p_original {
-        Peripheral::Array(p, dim) if !config.const_generic => {
+        Peripheral::Array(p, dim) => {
             let names: Vec<Cow<str>> = names(p, dim).map(|n| n.into()).collect();
             let names_str = names.iter().map(|n| n.to_sanitized_upper_case());
             let names_pc = names_str.clone().map(|n| Ident::new(&n, span));

--- a/src/util.rs
+++ b/src/util.rs
@@ -7,6 +7,7 @@ use inflections::Inflect;
 use proc_macro2::{Ident, Literal, Span, TokenStream};
 use quote::{quote, ToTokens};
 use std::path::{Path, PathBuf};
+use svd_rs::{MaybeArray, PeripheralInfo};
 
 use anyhow::{anyhow, bail, Context, Result};
 
@@ -221,10 +222,10 @@ pub fn escape_brackets(s: &str) -> String {
         })
 }
 
-pub fn name_of(register: &Register, ignore_group: bool) -> Cow<str> {
-    match register {
-        Register::Single(info) => info.fullname(ignore_group),
-        Register::Array(info, _) => replace_suffix(&info.fullname(ignore_group), "").into(),
+pub fn name_of<T: FullName>(maybe_array: &MaybeArray<T>, ignore_group: bool) -> Cow<str> {
+    match maybe_array {
+        MaybeArray::Single(info) => info.fullname(ignore_group),
+        MaybeArray::Array(info, _) => replace_suffix(&info.fullname(ignore_group), "").into(),
     }
 }
 
@@ -443,5 +444,11 @@ impl FullName for RegisterInfo {
             Some(group) if !ignore_group => format!("{}_{}", group, self.name).into(),
             _ => self.name.as_str().into(),
         }
+    }
+}
+
+impl FullName for PeripheralInfo {
+    fn fullname(&self, _ignore_group: bool) -> Cow<str> {
+        self.name.as_str().into()
     }
 }


### PR DESCRIPTION
## Brief Intro
- generate ArrayProxy of peripherals when const_generic is true
- generate separate struct of peripherals when const_generic is false

close issue: #492

## Design

**Notice:** This is my first try of implement this feature. Please provide suggestions for this PR to better implement this feature.

This PR aims to achieve what issue #492 is asking for. This PR implements a basic try of generating codes depending on the `const_generic` flag.

Let's say we have an svd file with descriptions of peripherals like this:

```XML
<peripheral>
    <dim>2</dim>
    <dimIncrement>0x100</dimIncrement>
    <name>PTEST[%s]</name>
    <groupName>PGroup</groupName>
    <baseAddress>0x20000000</baseAddress>
    <addressBlock>
        <offset>0</offset>
        <size>0x100</size>
        <usage>registers</usage>
    </addressBlock>
    <registers>
        ...
    </registers>
</peripheral>
```

If the `const_generic` is `false`, there is no `ArrayProxy`. So I generate separate structs and only one mod:

```rust
pub struct PTEST0 {
    _marker: PhantomData<*const ()>,
}
...
impl PTEST0 {
    #[doc = r"Pointer to the register block"]
    pub const PTR: *const ptest::RegisterBlock = 0x2000_0000 as *const _;
    ...
}
impl Deref for PTEST0 {
    type Target = ptest::RegisterBlock;
    #[inline(always)]
    fn deref(&self) -> &Self::Target {
        unsafe { &*Self::PTR }
    }
}

pub struct PTEST1 {
    _marker: PhantomData<*const ()>,
}
...
impl PTEST1 {
    #[doc = r"Pointer to the register block"]
    pub const PTR: *const ptest::RegisterBlock = 0x2000_0100 as *const _;
    ...
}
impl Deref for PTEST1 {
    type Target = ptest::RegisterBlock;
    #[inline(always)]
    fn deref(&self) -> &Self::Target {
        unsafe { &*Self::PTR }
    }
}
#[doc = "PTEST"]
pub mod ptest;
```

**NOTICE:** The following design is actually incorrect and has been removed. See the following comment.
<details>
If the `const_generic` is `true`, we can use `ArrayProxy`. So I generate code like this:

```rust
pub struct PTEST {
    _marker: PhantomData<*const ()>,
}
...

pub struct Peripherals {
    #[doc = "PTEST"]
    pub PTEST: crate::ArrayProxy<PTEST, 2usize, 0x0100>,
...
impl Peripherals {
...
    pub unsafe fn steal() -> Self {
        DEVICE_PERIPHERALS = true;
        Peripherals {
            PTEST: crate::ArrayProxy::new(),
```

Since `_array` is a private field of `ArrayProxy`, I add a `new` method to implement the `steal` method of `Peripherals`.
</details>
I also add the support of using `name_of` on `MaybeArray<PeripheralInfo>` to achieve this implementation.

Well, I haven't fully tested this implementation yet. So there may be problems that need to be solved.