### PR TITLE
Enum typename considering name in enumeratedValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Generated enum names now consider `name` field in `enumeratedValues`
+
 ## [v0.24.0] - 2022-05-12
 
 [commits][v0.24.0]

--- a/src/util.rs
+++ b/src/util.rs
@@ -124,6 +124,10 @@ pub trait ToSanitizedUpperCase {
     fn to_sanitized_upper_case(&self) -> Cow<str>;
 }
 
+pub trait ToSanitizedConstantCase {
+    fn to_sanitized_constant_case(&self) -> Cow<str>;
+}
+
 pub trait ToSanitizedSnakeCase {
     fn to_sanitized_not_keyword_snake_case(&self) -> Cow<str>;
     fn to_sanitized_snake_case(&self) -> Cow<str> {
@@ -178,6 +182,19 @@ impl ToSanitizedUpperCase for str {
                 Cow::from(format!("_{}", s.to_upper_case()))
             }
             _ => Cow::from(s.to_upper_case()),
+        }
+    }
+}
+
+impl ToSanitizedConstantCase for str {
+    fn to_sanitized_constant_case(&self) -> Cow<str> {
+        let s = self.replace(BLACKLIST_CHARS, "");
+
+        match s.chars().next().unwrap_or('\0') {
+            '0' | '1' | '2' | '3' | '4' | '5' | '6' | '7' | '8' | '9' => {
+                Cow::from(format!("_{}", s.to_constant_case()))
+            }
+            _ => Cow::from(s.to_constant_case()),
         }
     }
 }


### PR DESCRIPTION
svd2rust has a good mechanism to parse enumeratedValues into Rust enums. However, current code would pick name of the first field the enum resides, and use `pub type` to re-export it into other names.

SVD files provide `name` field in enumeratedValues, this commit make use of them to name the Rust enums it generated. After this commit, more information of SVD file is considered in output pac crate. Users may also discover a significant drop in amount of types, which will speed up rustdoc generation and crate compilation.

Before this pull request:
<details>

![图片](https://user-images.githubusercontent.com/40385009/169642280-9b95b8df-6088-402e-85e9-2918fa8b1896.png)
</details>

After this pull request:
<details>

Note that INTERRUPT_ENABLE_A comes from enumeration name InterruptEnable, but not register name interrupt_enable.
![图片](https://user-images.githubusercontent.com/40385009/169642143-6d298868-1141-49e5-8f4e-70d5b62bb4b3.png)
</details>

SVD file for this example:
<details>

```xml
            <field>
              <name>fifo_error_enable</name>
              <description>Transmit or receive FIFO error interrupt enable</description>
              <lsb>29</lsb>
              <msb>29</msb>
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
              <enumeratedValues>
                <name>InterruptEnable</name>
                <enumeratedValue>
                  <name>enable</name>
                  <description>Enable interrupt</description>
                  <value>1</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>disable</name>
                  <description>Disable interrupt</description>
                  <value>0</value>
                </enumeratedValue>
              </enumeratedValues>
            </field>
            <field>
              <name>arbitrate_lost_enable</name>
              <description>Arbitration lost interrupt enable</description>
              <lsb>28</lsb>
              <msb>28</msb>
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
              <enumeratedValues derivedFrom="InterruptEnable" />
            </field>
            <field>
              <name>not_acknowledged_enable</name>
              <description>Not-acknowledged response interrupt enable</description>
              <lsb>27</lsb>
              <msb>27</msb>
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
              <enumeratedValues derivedFrom="InterruptEnable" />
            </field>
<!-- and all other fields in this register -->
```
</details>
