### PR TITLE
Make binary dependencies optional

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,7 +69,7 @@ jobs:
             options: all
         include:
           # Test MSRV
-          - rust: 1.51.0
+          - rust: 1.60.0
             vendor: Nordic
 
           # Use nightly for architectures which don't support stable

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 
 - Make binary dependencies optional
+- Make JSON and YAML formats optional
+- Bump MSRV to 1.60
 
 ## [v0.24.0] - 2022-05-12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Make binary dependencies optional
+
 ## [v0.24.0] - 2022-05-12
 
 [commits][v0.24.0]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,10 @@ path = "src/main.rs"
 required-features = ["bin"]
 
 [features]
-default = ["bin"]
+default = ["bin", "json", "yaml"]
 bin = ["dep:clap", "dep:clap_conf", "dep:env_logger"]
+json = ["dep:serde_json"]
+yaml = ["dep:serde_yaml"]
 
 [dependencies]
 cast = "0.3"
@@ -51,8 +53,8 @@ quote = "1.0"
 proc-macro2 = "1.0"
 anyhow = "1.0"
 thiserror = "1.0"
-serde_json = "1.0.79"
-serde_yaml = "0.8.23"
+serde_json = { version = "1.0.79", optional = true }
+serde_yaml = { version = "0.8.23", optional = true }
 
 [dependencies.svd-parser]
 features = ["expand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ name = "svd2rust"
 repository = "https://github.com/rust-embedded/svd2rust/"
 version = "0.24.0"
 readme = "README.md"
+rust-version = "1.60"
 
 [package.metadata.deb]
 section = "rust"
@@ -37,7 +38,7 @@ required-features = ["bin"]
 
 [features]
 default = ["bin"]
-bin = ["clap", "clap_conf", "env_logger"]
+bin = ["dep:clap", "dep:clap_conf", "dep:env_logger"]
 
 [dependencies]
 cast = "0.3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,12 +33,17 @@ section = "rust"
 doc = false
 name = "svd2rust"
 path = "src/main.rs"
+required-features = ["bin"]
+
+[features]
+default = ["bin"]
+bin = ["clap", "clap_conf", "env_logger"]
 
 [dependencies]
 cast = "0.3"
-clap = "2.33"
-clap_conf = "0.1.5"
-env_logger = "0.9"
+clap = { version = "2.33", optional = true }
+clap_conf = { version = "0.1.5", optional = true }
+env_logger = { version = "0.9", optional = true }
 inflections = "1.1"
 log = { version = "~0.4", features = ["std"] }
 quote = "1.0"

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-The **generated code** is guaranteed to compile on stable Rust 1.51.0 and up.
+The **generated code** is guaranteed to compile on stable Rust 1.60.0 and up.
 
-If you encounter compilation errors on any stable version newer than 1.51.0, please open an issue.
+If you encounter compilation errors on any stable version newer than 1.60.0, please open an issue.
 
 # Testing Locally
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -582,8 +582,10 @@ pub fn load_from(input: &str, config: &crate::util::Config) -> Result<svd::Devic
             svd_parser::parse_with_config(input, &parser_config)
                 .with_context(|| "Error parsing SVD XML file".to_string())?
         }
+        #[cfg(feature = "yaml")]
         SourceType::Yaml => serde_yaml::from_str(input)
             .with_context(|| "Error parsing SVD YAML file".to_string())?,
+        #[cfg(feature = "json")]
         SourceType::Json => serde_json::from_str(input)
             .with_context(|| "Error parsing SVD JSON file".to_string())?,
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -88,7 +88,9 @@ impl Default for Target {
 #[derive(Clone, Copy, PartialEq, Debug)]
 pub enum SourceType {
     Xml,
+    #[cfg(feature = "yaml")]
     Yaml,
+    #[cfg(feature = "json")]
     Json,
 }
 
@@ -102,9 +104,11 @@ impl SourceType {
     /// Make a new [`Source`] from a given extension.
     pub fn from_extension(s: &str) -> Option<Self> {
         match s {
-            "yml" | "yaml" => Some(Self::Yaml),
-            "json" => Some(Self::Json),
             "svd" | "xml" => Some(Self::Xml),
+            #[cfg(feature = "yaml")]
+            "yml" | "yaml" => Some(Self::Yaml),
+            #[cfg(feature = "json")]
+            "json" => Some(Self::Json),
             _ => None,
         }
     }


### PR DESCRIPTION
Users can now disable binary dependencies if they don't need them, closes #618.

I think we could also make JSON and YAML optional and keep them enabled by default. What do you think?