### PR TITLE
field writer's always generic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Make field writer always generic around bit offset
 - Make binary dependencies optional
 - Make JSON and YAML formats optional
 - Bump MSRV to 1.60


### PR DESCRIPTION
Alternative to #621 

Reverts [760670616ed807041767cade52518291c810177c](https://github.com/rust-embedded/svd2rust/pull/598/commits/760670616ed807041767cade52518291c810177c)

Advantages:
- easier generation logic, identical for single fields and field arrays (less potential bugs)
- easier to integrate #612
- less boilerplate, faster compilation

Disadvantages:
- as writer not attached to offsets, not obvious meaning of writer
- bigger firmware in debug mode? (need check)