### PR TITLE
Use one trait for all cases; use constant case for structures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Use constant case for structure names; internal rearrangements for
+  case conversation traits
 - Add new feature `feature_group` which will generate cfg attribute for
   every group name when it is on
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -1,5 +1,4 @@
 use crate::svd::{array::names, Device, Peripheral};
-use crate::util::{ToSanitizedSnakeCase, U32Ext};
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{quote, ToTokens};
 
@@ -8,7 +7,7 @@ use std::borrow::Cow;
 use std::fs::File;
 use std::io::Write;
 
-use crate::util::{self, Config, ToSanitizedUpperCase};
+use crate::util::{self, Config, ToSanitizedCase, U32Ext};
 use crate::Target;
 use anyhow::{Context, Result};
 
@@ -261,7 +260,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         match p {
             Peripheral::Single(_p) => {
                 let p_name = util::name_of(p, config.ignore_groups);
-                let p = p_name.to_sanitized_upper_case();
+                let p = p_name.to_sanitized_constant_case();
                 let id = Ident::new(&p, Span::call_site());
                 fields.extend(quote! {
                     #[doc = #p]
@@ -272,7 +271,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             }
             Peripheral::Array(_p, dim_element) => {
                 let p_names: Vec<Cow<str>> = names(p, dim_element).map(|n| n.into()).collect();
-                let p = p_names.iter().map(|p| p.to_sanitized_upper_case());
+                let p = p_names.iter().map(|p| p.to_sanitized_constant_case());
                 let ids_f = p.clone().map(|p| Ident::new(&p, Span::call_site()));
                 let ids_e = ids_f.clone();
                 fields.extend(quote! {

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -6,7 +6,7 @@ use cast::u64;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 
-use crate::util::{self, ToSanitizedSnakeCase, ToSanitizedUpperCase};
+use crate::util::{self, ToSanitizedCase};
 use crate::{Config, Target};
 use anyhow::Result;
 
@@ -43,8 +43,8 @@ pub fn render(
         }
         pos += 1;
 
-        let name_uc = Ident::new(
-            &interrupt.0.name.to_sanitized_upper_case(),
+        let name_constant_case = Ident::new(
+            &interrupt.0.name.to_sanitized_constant_case(),
             Span::call_site(),
         );
         let description = format!(
@@ -78,12 +78,12 @@ pub fn render(
         variants.extend(quote! {
             #[doc = #description]
             #feature_attribute
-            #name_uc = #value,
+            #name_constant_case = #value,
         });
 
         from_arms.extend(quote! {
             #feature_attribute
-            #value => Ok(Interrupt::#name_uc),
+            #value => Ok(Interrupt::#name_constant_case),
         });
 
         if feature_attribute_flag {
@@ -91,12 +91,12 @@ pub fn render(
                 #not_feature_attribute
                 Vector { _reserved: 0 },
                 #feature_attribute
-                Vector { _handler: #name_uc },
+                Vector { _handler: #name_constant_case },
             });
         } else {
-            elements.extend(quote!(Vector { _handler: #name_uc },));
+            elements.extend(quote!(Vector { _handler: #name_constant_case },));
         }
-        names.push(name_uc);
+        names.push(name_constant_case);
         names_cfg_attr.push(feature_attribute);
     }
 


### PR DESCRIPTION
This pull request is the first part of https://github.com/rust-embedded/svd2rust/pull/612. It merges all `ToSanitizedXxxCase` traits in one `ToSanitizedCase` trait. It also replace all use of upper cases into constant cases, in case the source file did not provide underline between words. It rename variables related to cases, for example `name_sc` to `name_snake_case` to be explict.

The changed code merges original case conversation traits into one trait:

```rust
/// Convert self string into specific case without overlapping to svd2rust internal names
pub trait ToSanitizedCase {
    /// Convert self into PascalCase.
    ///
    /// Use on name of enumeration values.
    fn to_sanitized_pascal_case(&self) -> Cow<str>;
    /// Convert self into CONSTANT_CASE.
    ///
    /// Use on name of reader structs, writer structs and enumerations.
    fn to_sanitized_constant_case(&self) -> Cow<str>;
    /// Convert self into snake_case, must use only if the target is used with extra prefix or suffix.
    fn to_sanitized_not_keyword_snake_case(&self) -> Cow<str>;
    /// Convert self into snake_case target and ensure target is not a Rust keyword.
    ///
    /// If the sanitized target is a Rust keyword, this function adds an underline `_`
    /// to it.
    ///
    /// Use on name of peripheral modules, register modules and field modules.
    fn to_sanitized_snake_case(&self) -> Cow<str> {
        let s = self.to_sanitized_not_keyword_snake_case();
        sanitize_keyword(s)
    }
}
```

Note on replacing upper case to constant case: if the source svd file provide enumeration name `InterruptEnable`, it converts to constant case `INTERRUPT_ENABLE` instead of less readable `INTERRUPTENABLE` in current code.