### PR TITLE
Rework: Enum typename considering name in enumeratedValues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Generated enum names now consider `name` field in `enumeratedValues`
 - Use constant case for structure names; internal rearrangements for
   case conversation traits
 - Add new feature `feature_group` which will generate cfg attribute for


### PR DESCRIPTION
~Marked as draft: this pull request depends on https://github.com/rust-embedded/svd2rust/pull/626, and should be merged after that pull request is merged.~ Ready for review as #626 is merged.

This pull request is a rework to https://github.com/rust-embedded/svd2rust/pull/612; commits in this pull request only considers enumeration name other than writer structure and reader structure. Names to those two proxy structures are yet to be discussed.

svd2rust has a good mechanism to parse enumeratedValues into Rust enums. However, current code would pick name of the first field the enum resides, and use pub type to re-export it into other names.

SVD files provide `name` field in enumeratedValues, this commit make use of them to name the Rust enums it generated. After this commit, more information of SVD file is considered in output pac crate. Users may also discover a significant drop in amount of types, which will speed up rustdoc generation and crate compilation.

After this pull request is merged, we can discuss on how the read proxy and write proxy should be named as is mentioned in [comment at #612](https://github.com/rust-embedded/svd2rust/pull/612#issuecomment-1133645637).

Before this pull request:
<details>

![图片](https://user-images.githubusercontent.com/40385009/178151338-2e327886-0ce7-44f8-b12c-8ef9ee8d671a.png)
</details>

After this pull request: 
<details>

![图片](https://user-images.githubusercontent.com/40385009/178151280-c2b83445-2f15-4a18-9d9a-f511c6ea85f8.png)
</details>

SVD file for this example:
<details>

```xml
        <register>
          <name>interrupt</name>
          <description>Interrupt enables, states and masks</description>
          <addressOffset>0x04</addressOffset>
          <resetValue>0x3f003f00</resetValue>
          <resetMask>0xffffffff</resetMask>
          <fields>
            <field>
              <name>fifo_error_enable</name>
              <description>Transmit or receive FIFO error interrupt enable</description>
              <lsb>29</lsb>
              <msb>29</msb>
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
              <enumeratedValues>
                <name>InterruptEnable</name>
                <enumeratedValue>
                  <name>enable</name>
                  <description>Enable interrupt</description>
                  <value>1</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>disable</name>
                  <description>Disable interrupt</description>
                  <value>0</value>
                </enumeratedValue>
              </enumeratedValues>
            </field>
            <field>
              <name>arbitrate_lost_enable</name>
              <description>Arbitration lost interrupt enable</description>
              <lsb>28</lsb>
              <msb>28</msb>
              <writeConstraint>
                <useEnumeratedValues>true</useEnumeratedValues>
              </writeConstraint>
              <enumeratedValues derivedFrom="InterruptEnable" />
            </field>
<!-- ...... -->
```
</details>