### PR TITLE
feat: remove `sequential_indexes` check in generating of field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Remove `sequential_indexes` check in generating of field.
 - Refactor `periperal.rs`
 - use `svd_parser::expand::Index` for derive
 - Generated enum names now consider `name` field in `enumeratedValues`

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -401,13 +401,6 @@ pub fn fields(
             Field::Array(_, de) => {
                 let first = if let Some(dim_index) = &de.dim_index {
                     if let Ok(first) = dim_index[0].parse::<u32>() {
-                        let sequential_indexes = dim_index
-                            .iter()
-                            .map(|element| element.parse::<u32>())
-                            .eq((first..de.dim + first).map(Ok));
-                        if !sequential_indexes {
-                            return Err(anyhow!("unsupported array indexes in {}", f.name));
-                        }
                         first
                     } else {
                         0


### PR DESCRIPTION
remove check to allow descent and other orders of `dimIndex`

close: #639