### PR TITLE
register & cluster aliases instead of clone when derive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Create aliases for derived registers & clusters
 - Move cluster struct inside mod
 - Support non-sequential field arrays
 - Use inlined variables in `format!` (Rust 1.58)

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -877,10 +877,9 @@ fn render_ercs(
                     rpath = derive_register(reg, &dpath, path, index)?;
                 }
                 let reg_name = &reg.name;
-                let rpath = rpath.unwrap_or_else(|| path.new_register(reg_name));
 
-                let rendered_reg =
-                    register::render(reg, &rpath, index, config).with_context(|| {
+                let rendered_reg = register::render(reg, path, &rpath, index, config)
+                    .with_context(|| {
                         let descrip = reg.description.as_deref().unwrap_or("No description");
                         format!(
                             "Error rendering register\nName: {reg_name}\nDescription: {descrip}"

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -8,9 +8,12 @@ use crate::svd::{
 use log::{debug, trace, warn};
 use proc_macro2::{Ident, Punct, Spacing, Span, TokenStream};
 use quote::{quote, ToTokens};
-use syn::{parse_str, Token};
+use syn::Token;
 
-use crate::util::{self, unsuffixed, Config, FullName, ToSanitizedCase, BITS_PER_BYTE};
+use crate::util::{
+    self, array_proxy_type, name_to_ty, name_to_wrapped_ty, new_syn_u32, unsuffixed, Config,
+    FullName, ToSanitizedCase, BITS_PER_BYTE,
+};
 use anyhow::{anyhow, bail, Context, Result};
 
 use crate::generate::register;
@@ -686,7 +689,7 @@ fn expand_cluster(cluster: &Cluster, config: &Config) -> Result<Vec<RegisterBloc
                     let span = Span::call_site();
                     let mut accessors = TokenStream::new();
                     let nb_name = util::replace_suffix(&info.name, "");
-                    let ty = name_to_ty(&nb_name)?;
+                    let ty = name_to_ty(&nb_name);
                     let nb_name_cs = nb_name.to_snake_case_ident(span);
                     for (i, idx) in array_info.indexes().enumerate() {
                         let idx_name =
@@ -717,14 +720,13 @@ fn expand_cluster(cluster: &Cluster, config: &Config) -> Result<Vec<RegisterBloc
             } else if sequential_indexes_from0 && config.const_generic {
                 // Include a ZST ArrayProxy giving indexed access to the
                 // elements.
-                cluster_expanded.push(array_proxy(info, array_info)?);
+                cluster_expanded.push(array_proxy(info, array_info));
             } else {
                 let ty_name = util::replace_suffix(&info.name, "");
-                let ty = name_to_ty(&ty_name)?;
+                let ty = syn::Type::Path(name_to_ty(&ty_name));
 
                 for (field_num, idx) in array_info.indexes().enumerate() {
                     let nb_name = util::replace_suffix(&info.name, &idx);
-
                     let syn_field =
                         new_syn_field(nb_name.to_snake_case_ident(Span::call_site()), ty.clone());
 
@@ -790,7 +792,7 @@ fn expand_register(register: &Register, config: &Config) -> Result<Vec<RegisterB
                     let span = Span::call_site();
                     let mut accessors = TokenStream::new();
                     let nb_name = util::replace_suffix(&info.fullname(config.ignore_groups), "");
-                    let ty = name_to_wrapped_ty(&nb_name)?;
+                    let ty = name_to_wrapped_ty(&nb_name);
                     let nb_name_cs = nb_name.to_snake_case_ident(span);
                     let info_name = info.fullname(config.ignore_groups);
                     for (i, idx) in array_info.indexes().enumerate() {
@@ -822,11 +824,10 @@ fn expand_register(register: &Register, config: &Config) -> Result<Vec<RegisterB
             } else {
                 let info_name = info.fullname(config.ignore_groups);
                 let ty_name = util::replace_suffix(&info_name, "");
-                let ty = name_to_wrapped_ty(&ty_name)?;
+                let ty = name_to_wrapped_ty(&ty_name);
 
                 for (field_num, idx) in array_info.indexes().enumerate() {
                     let nb_name = util::replace_suffix(&info_name, &idx);
-
                     let syn_field =
                         new_syn_field(nb_name.to_snake_case_ident(Span::call_site()), ty.clone());
 
@@ -912,7 +913,7 @@ fn cluster_block(
 
     let name_snake_case = mod_name.to_snake_case_ident(Span::call_site());
 
-    let struct_path = name_to_ty(&mod_name)?;
+    let struct_path = name_to_ty(&mod_name);
 
     Ok(quote! {
         #[doc = #description]
@@ -933,15 +934,13 @@ fn register_to_syn_field(register: &Register, ignore_group: bool) -> Result<syn:
     Ok(match register {
         Register::Single(info) => {
             let info_name = info.fullname(ignore_group);
-            let ty = name_to_wrapped_ty(&info_name)
-                .with_context(|| format!("Error converting register name {info_name}"))?;
+            let ty = name_to_wrapped_ty(&info_name);
             new_syn_field(info_name.to_snake_case_ident(Span::call_site()), ty)
         }
         Register::Array(info, array_info) => {
             let info_name = info.fullname(ignore_group);
             let nb_name = util::replace_suffix(&info_name, "");
-            let ty = name_to_wrapped_ty(&nb_name)
-                .with_context(|| format!("Error converting register name {nb_name}"))?;
+            let ty = name_to_wrapped_ty(&nb_name);
             let array_ty = new_syn_array(ty, array_info.dim);
 
             new_syn_field(nb_name.to_snake_case_ident(Span::call_site()), array_ty)
@@ -950,42 +949,31 @@ fn register_to_syn_field(register: &Register, ignore_group: bool) -> Result<syn:
 }
 
 /// Return an syn::Type for an ArrayProxy.
-fn array_proxy(
-    info: &ClusterInfo,
-    array_info: &DimElement,
-) -> Result<RegisterBlockField, syn::Error> {
+fn array_proxy(info: &ClusterInfo, array_info: &DimElement) -> RegisterBlockField {
     let ty_name = util::replace_suffix(&info.name, "");
-    let tys = name_to_ty_str(&ty_name);
+    let ty = name_to_ty(&ty_name);
 
-    let ap_path = parse_str::<syn::TypePath>(&format!(
-        "crate::ArrayProxy<{tys}, {}, {}>",
-        array_info.dim,
-        util::hex(array_info.dim_increment as u64).into_token_stream(),
-    ))?;
+    let ap_path = array_proxy_type(ty, array_info);
 
-    Ok(RegisterBlockField {
-        syn_field: new_syn_field(
-            ty_name.to_snake_case_ident(Span::call_site()),
-            ap_path.into(),
-        ),
+    RegisterBlockField {
+        syn_field: new_syn_field(ty_name.to_snake_case_ident(Span::call_site()), ap_path),
         description: info.description.as_ref().unwrap_or(&info.name).into(),
         offset: info.address_offset,
         size: 0,
         accessors: None,
-    })
+    }
 }
 
 /// Convert a parsed `Cluster` into its `Field` equivalent
 fn cluster_to_syn_field(cluster: &Cluster) -> Result<syn::Field, syn::Error> {
     Ok(match cluster {
         Cluster::Single(info) => {
-            let ty_name = util::replace_suffix(&info.name, "");
-            let ty = name_to_ty(&ty_name)?;
+            let ty = syn::Type::Path(name_to_ty(&info.name));
             new_syn_field(info.name.to_snake_case_ident(Span::call_site()), ty)
         }
         Cluster::Array(info, array_info) => {
             let ty_name = util::replace_suffix(&info.name, "");
-            let ty = name_to_ty(&ty_name)?;
+            let ty = syn::Type::Path(name_to_ty(&ty_name));
             let array_ty = new_syn_array(ty, array_info.dim);
 
             new_syn_field(ty_name.to_snake_case_ident(Span::call_site()), array_ty)
@@ -1014,40 +1002,4 @@ fn new_syn_array(ty: syn::Type, len: u32) -> syn::Type {
         semi_token: Token![;](span),
         len: new_syn_u32(len, span),
     })
-}
-
-fn new_syn_u32(len: u32, span: Span) -> syn::Expr {
-    syn::Expr::Lit(syn::ExprLit {
-        attrs: Vec::new(),
-        lit: syn::Lit::Int(syn::LitInt::new(&len.to_string(), span)),
-    })
-}
-
-fn name_to_ty_str(name: &str) -> String {
-    format!(
-        "{}::{}",
-        name.to_sanitized_snake_case(),
-        name.to_sanitized_constant_case()
-    )
-}
-
-fn name_to_ty(name: &str) -> Result<syn::Type, syn::Error> {
-    let ident = name_to_ty_str(name);
-    parse_str::<syn::TypePath>(&ident).map(syn::Type::Path)
-}
-
-fn name_to_wrapped_ty_str(name: &str) -> String {
-    format!(
-        "crate::Reg<{}::{}_SPEC>",
-        &name.to_sanitized_snake_case(),
-        &name.to_sanitized_constant_case(),
-    )
-}
-
-fn name_to_wrapped_ty(name: &str) -> Result<syn::Type> {
-    let ident = name_to_wrapped_ty_str(name);
-    parse_str::<syn::TypePath>(&ident)
-        .map(syn::Type::Path)
-        .map_err(anyhow::Error::from)
-        .with_context(|| format!("Determining syn::TypePath from ident \"{ident}\" failed"))
 }

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -19,7 +19,7 @@ use syn::punctuated::Punctuated;
 pub fn render(
     register: &Register,
     path: &BlockPath,
-    dpath: &Option<RegisterPath>,
+    dpath: Option<RegisterPath>,
     index: &Index,
     config: &Config,
 ) -> Result<TokenStream> {
@@ -44,8 +44,7 @@ pub fn render(
         pub type #name_constant_case = #wrapped_name;
     });
 
-    let mod_items = if let Some(dpath) = dpath {
-        let mut mod_items = TokenStream::new();
+    let mod_items = if let Some(dpath) = dpath.as_ref() {
         let mut derived_spec = if &dpath.block == path {
             let mut segments = Punctuated::new();
             segments.push(path_segment(Ident::new("super", span)));
@@ -62,11 +61,10 @@ pub fn render(
             format!("{}_SPEC", dname).to_constant_case_ident(span),
         ));
 
-        mod_items.extend(quote! {
+        quote! {
             #[doc = #description]
             pub use #derived_spec as #name_constant_case_spec;
-        });
-        mod_items
+        }
     } else {
         render_register_mod(register, &path.new_register(&register.name), index, config)?
     };

--- a/src/util.rs
+++ b/src/util.rs
@@ -6,6 +6,7 @@ use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
+use svd_parser::expand::BlockPath;
 use svd_rs::{MaybeArray, PeripheralInfo};
 
 use syn::{
@@ -439,6 +440,12 @@ pub fn path_segment(ident: Ident) -> PathSegment {
         ident,
         arguments: PathArguments::None,
     }
+}
+
+pub fn parent(p: &BlockPath) -> BlockPath {
+    let mut p = p.clone();
+    p.path.pop().unwrap();
+    p
 }
 
 pub trait U32Ext {

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,17 @@
 use std::borrow::Cow;
 
-use crate::svd::{Access, Device, Field, RegisterInfo, RegisterProperties};
+use crate::svd::{Access, Device, DimElement, Field, RegisterInfo, RegisterProperties};
 use inflections::Inflect;
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
 use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use svd_rs::{MaybeArray, PeripheralInfo};
-use syn::parse_str;
+
+use syn::{
+    punctuated::Punctuated, token::Colon2, AngleBracketedGenericArguments, GenericArgument, Lit,
+    LitInt, PathArguments, PathSegment, Token, Type, TypePath,
+};
 
 use anyhow::{anyhow, bail, Result};
 
@@ -282,7 +286,7 @@ pub fn access_of(properties: &RegisterProperties, fields: Option<&[Field]>) -> A
     })
 }
 
-pub fn digit_or_hex(n: u64) -> syn::LitInt {
+pub fn digit_or_hex(n: u64) -> LitInt {
     if n < 10 {
         unsuffixed(n)
     } else {
@@ -291,14 +295,14 @@ pub fn digit_or_hex(n: u64) -> syn::LitInt {
 }
 
 /// Turns `n` into an unsuffixed separated hex token
-pub fn hex(n: u64) -> syn::LitInt {
+pub fn hex(n: u64) -> LitInt {
     let (h4, h3, h2, h1) = (
         (n >> 48) & 0xffff,
         (n >> 32) & 0xffff,
         (n >> 16) & 0xffff,
         n & 0xffff,
     );
-    syn::LitInt::new(
+    LitInt::new(
         &(if h4 != 0 {
             format!("0x{h4:04x}_{h3:04x}_{h2:04x}_{h1:04x}")
         } else if h3 != 0 {
@@ -317,29 +321,124 @@ pub fn hex(n: u64) -> syn::LitInt {
 }
 
 /// Turns `n` into an unsuffixed token
-pub fn unsuffixed(n: u64) -> syn::LitInt {
-    syn::LitInt::new(&n.to_string(), Span::call_site())
+pub fn unsuffixed(n: u64) -> LitInt {
+    LitInt::new(&n.to_string(), Span::call_site())
 }
 
-pub fn unsuffixed_or_bool(n: u64, width: u32) -> syn::Lit {
+pub fn unsuffixed_or_bool(n: u64, width: u32) -> Lit {
     if width == 1 {
-        syn::Lit::Bool(syn::LitBool::new(n != 0, Span::call_site()))
+        Lit::Bool(syn::LitBool::new(n != 0, Span::call_site()))
     } else {
-        syn::Lit::Int(unsuffixed(n))
+        Lit::Int(unsuffixed(n))
     }
 }
 
-pub fn register_path_to_ty(
-    rpath: &svd_parser::expand::RegisterPath,
-) -> Result<syn::Type, syn::Error> {
-    let mut ident = format!("crate::{}", &rpath.peripheral().to_sanitized_snake_case());
-    for ps in &rpath.block.path {
-        ident.push_str("::");
-        ident.push_str(&ps.to_sanitized_snake_case());
+pub fn new_syn_u32(len: u32, span: Span) -> syn::Expr {
+    syn::Expr::Lit(syn::ExprLit {
+        attrs: Vec::new(),
+        lit: syn::Lit::Int(syn::LitInt::new(&len.to_string(), span)),
+    })
+}
+
+pub fn array_proxy_type(ty: TypePath, array_info: &DimElement) -> Type {
+    let span = Span::call_site();
+    let inner_path = GenericArgument::Type(Type::Path(ty));
+    let mut args = Punctuated::new();
+    args.push(inner_path);
+    args.push(GenericArgument::Const(new_syn_u32(array_info.dim, span)));
+    args.push(GenericArgument::Const(syn::Expr::Lit(syn::ExprLit {
+        attrs: Vec::new(),
+        lit: syn::Lit::Int(hex(array_info.dim_increment as u64)),
+    })));
+    let arguments = PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+        colon2_token: None,
+        lt_token: Token![<](span),
+        args,
+        gt_token: Token![>](span),
+    });
+
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(Ident::new("crate", span)));
+    segments.push(PathSegment {
+        ident: Ident::new("ArrayProxy", span),
+        arguments,
+    });
+    Type::Path(type_path(segments))
+}
+
+pub fn name_to_ty(name: &str) -> TypePath {
+    let span = Span::call_site();
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(name.to_snake_case_ident(span)));
+    segments.push(path_segment(name.to_constant_case_ident(span)));
+    type_path(segments)
+}
+
+pub fn name_to_wrapped_ty(name: &str) -> Type {
+    let span = Span::call_site();
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(name.to_snake_case_ident(span)));
+    segments.push(path_segment(
+        format!("{name}_SPEC").to_constant_case_ident(span),
+    ));
+    let inner_path = GenericArgument::Type(Type::Path(type_path(segments)));
+    let mut args = Punctuated::new();
+    args.push(inner_path);
+    let arguments = PathArguments::AngleBracketed(AngleBracketedGenericArguments {
+        colon2_token: None,
+        lt_token: Token![<](span),
+        args,
+        gt_token: Token![>](span),
+    });
+
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(Ident::new("crate", span)));
+    segments.push(PathSegment {
+        ident: Ident::new("Reg", span),
+        arguments,
+    });
+    Type::Path(type_path(segments))
+}
+
+pub fn block_path_to_ty(bpath: &svd_parser::expand::BlockPath, span: Span) -> TypePath {
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(Ident::new("crate", span)));
+    segments.push(path_segment(bpath.peripheral.to_snake_case_ident(span)));
+    for ps in &bpath.path {
+        segments.push(path_segment(ps.to_snake_case_ident(span)));
     }
-    ident.push_str("::");
-    ident.push_str(&rpath.name.to_sanitized_snake_case());
-    parse_str::<syn::TypePath>(&ident).map(syn::Type::Path)
+    type_path(segments)
+}
+
+pub fn register_path_to_ty(rpath: &svd_parser::expand::RegisterPath, span: Span) -> TypePath {
+    let mut p = block_path_to_ty(&rpath.block, span);
+    p.path
+        .segments
+        .push(path_segment(rpath.name.to_snake_case_ident(span)));
+    p
+}
+
+pub fn ident_to_path(ident: Ident) -> TypePath {
+    let mut segments = Punctuated::new();
+    segments.push(path_segment(ident));
+    type_path(segments)
+}
+
+pub fn type_path(segments: Punctuated<PathSegment, Colon2>) -> TypePath {
+    TypePath {
+        qself: None,
+        path: syn::Path {
+            leading_colon: None,
+            segments,
+        },
+    }
+}
+
+pub fn path_segment(ident: Ident) -> PathSegment {
+    PathSegment {
+        ident,
+        arguments: PathArguments::None,
+    }
 }
 
 pub trait U32Ext {


### PR DESCRIPTION
+ construct pathes manually instead of parse