### PR TITLE
Fixing compilation error when re-exporting module with same name as a Rust package.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Use `critical_section::with` instead of `interrupt::free` for `Peripherals::take`.
 - Bring documentation on how to generate MSP430 PACs up to date (in line with
   [msp430_svd](https://github.com/pftbest/msp430_svd)).
+- Prefix submodule path with self:: when reexporting submodules to avoid ambiguity in crate path.
 
 ## [v0.25.1] - 2022-08-22
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -114,7 +114,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                 out.extend(quote! {
                     #[doc = #description]
                     #feature_any_attribute
-                    pub use #base as #name_snake_case;
+                    pub use self::#base as #name_snake_case;
                 });
                 return Ok(out);
             }
@@ -170,7 +170,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                 out.extend(quote! {
                     #[doc = #description]
                     #feature_attribute
-                    pub use #base as #name_snake_case;
+                    pub use self::#base as #name_snake_case;
                 });
                 return Ok(out);
             }
@@ -1014,8 +1014,8 @@ fn cluster_block(
 
         Ok(quote! {
             #[doc = #description]
-            pub use #derived as #name_constant_case;
-            pub use #mod_derived as #name_snake_case;
+            pub use self::#derived as #name_constant_case;
+            pub use self::#mod_derived as #name_snake_case;
         })
     } else {
         let cpath = path.new_cluster(&c.name);
@@ -1032,7 +1032,7 @@ fn cluster_block(
 
         Ok(quote! {
             #[doc = #description]
-            pub use #name_snake_case::#name_constant_case;
+            pub use self::#name_snake_case::#name_constant_case;
 
             ///Cluster
             #[doc = #description]


### PR DESCRIPTION
Added self:: when referencing submodule to avoid ambiguity fix issue https://github.com/rust-embedded/svd2rust/issues/657