### PR TITLE
Disjoint arrays

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bring documentation on how to generate MSP430 PACs up to date (in line with
   [msp430_svd](https://github.com/pftbest/msp430_svd)).
 - Prefix submodule path with self:: when reexporting submodules to avoid ambiguity in crate path.
+- Add handling for disjoint arrays
 
 ## [v0.25.1] - 2022-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Test patched STM32
 - simplify ci strategy
 - Fix generated code for MSP430 atomics
+- Add handling for disjoint arrays
 
 ## [v0.27.1] - 2022-10-25
 
@@ -40,7 +41,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bring documentation on how to generate MSP430 PACs up to date (in line with
   [msp430_svd](https://github.com/pftbest/msp430_svd)).
 - Prefix submodule path with self:: when reexporting submodules to avoid ambiguity in crate path.
-- Add handling for disjoint arrays
 
 ## [v0.25.1] - 2022-08-22
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,7 @@ thiserror = "1.0"
 serde = { version = "1.0", optional = true }
 serde_json = { version = "1.0.85", optional = true }
 serde_yaml = { version = "0.9.11", optional = true }
+regex = "1.6.0"
 
 [dependencies.svd-parser]
 features = ["expand"]


### PR DESCRIPTION
Solution 2 for #660 which pre-parses ERC type names and provides expansion information to the render functions. Works great with a few SVDs from the [Renesas RA DFP](https://www2.renesas.eu/Keil_MDK_Packs/Renesas.RA_DFP.4.0.0.pack) which tend to use disjoint arrays quite frequently.