### PR TITLE
bin: update dependency `clap` to version 4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Update dependency `clap` to version 4.0
+
 ## [v0.26.0] - 2022-10-07
 
 - Use edition 2021

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,16 +38,18 @@ required-features = ["bin"]
 
 [features]
 default = ["bin", "json", "yaml"]
-bin = ["dep:clap", "dep:clap_conf", "dep:env_logger"]
+bin = ["dep:clap", "dep:clap-verbosity-flag", "dep:env_logger", "serde", "dep:toml"]
 json = ["dep:serde_json"]
 yaml = ["dep:serde_yaml"]
 
 [dependencies]
-clap = { version = "2.34", optional = true }
-clap_conf = { version = "0.1.5", optional = true }
+clap = { version = "4.0", features = ["derive"], optional = true }
+clap-verbosity-flag = { version = "2.0", optional = true }
 env_logger = { version = "0.9", optional = true }
+serde = { version = "1", features = ["derive"], optional = true }
+toml = { version = "0.5", optional = true }
 inflections = "1.1"
-log = { version = "~0.4", features = ["std"] }
+log = { version = "~0.4", features = ["std", "serde"] }
 quote = "1.0"
 proc-macro2 = "1.0"
 anyhow = "1.0"

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -41,9 +41,9 @@ main() {
 
     case $OPTIONS in
         all)
-            const_generic="--const_generic"
+            const_generic="--const-generic"
             strict="--strict"
-            derive_more="--derive_more"
+            derive_more="--derive-more"
             ;;
         strict)
             const_generic=""
@@ -51,14 +51,14 @@ main() {
             derive_more=""
             ;;
         const)
-            const_generic="--const_generic"
+            const_generic="--const-generic"
             strict=""
             derive_more=""
             ;;
         derive_more)
             const_generic=""
             strict=""
-            derive_more="--derive_more"
+            derive_more="--derive-more"
             ;;
         *)
             const_generic=""

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -509,6 +509,7 @@ use quote::quote;
 use svd_parser::svd;
 
 pub mod generate;
+mod serde;
 pub mod util;
 
 pub use crate::util::{Config, Target};

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,0 +1,144 @@
+#![cfg(feature = "serde")]
+
+use crate::util::SourceType;
+use crate::util::{Target, SOURCE_TYPE_NAMES, TARGET_NAMES};
+use core::fmt;
+use core::str;
+use serde::{
+    de::{DeserializeSeed, EnumAccess, Error, Unexpected, VariantAccess, Visitor},
+    Deserialize, Deserializer,
+};
+
+impl<'de> Deserialize<'de> for Target {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct TargetIdentifier;
+
+        impl<'de> Visitor<'de> for TargetIdentifier {
+            type Value = Target;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("svd2rust target")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                Target::parse(s).map_err(|_| Error::unknown_variant(s, &TARGET_NAMES))
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant = str::from_utf8(value)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
+
+                self.visit_str(variant)
+            }
+        }
+
+        impl<'de> DeserializeSeed<'de> for TargetIdentifier {
+            type Value = Target;
+
+            fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_identifier(TargetIdentifier)
+            }
+        }
+
+        struct TargetEnum;
+
+        impl<'de> Visitor<'de> for TargetEnum {
+            type Value = Target;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("svd2rust target")
+            }
+
+            fn visit_enum<A>(self, value: A) -> Result<Self::Value, A::Error>
+            where
+                A: EnumAccess<'de>,
+            {
+                let (ans, variant) = value.variant_seed(TargetIdentifier)?;
+                // Every variant is a unit variant.
+                variant.unit_variant()?;
+                Ok(ans)
+            }
+        }
+
+        deserializer.deserialize_enum("Target", &TARGET_NAMES, TargetEnum)
+    }
+}
+
+impl<'de> Deserialize<'de> for SourceType {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct SourceTypeIdentifier;
+
+        impl<'de> Visitor<'de> for SourceTypeIdentifier {
+            type Value = SourceType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("svd2rust source type")
+            }
+
+            fn visit_str<E>(self, s: &str) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                SourceType::from_extension(s).ok_or(Error::unknown_variant(s, &SOURCE_TYPE_NAMES))
+            }
+
+            fn visit_bytes<E>(self, value: &[u8]) -> Result<Self::Value, E>
+            where
+                E: Error,
+            {
+                let variant = str::from_utf8(value)
+                    .map_err(|_| Error::invalid_value(Unexpected::Bytes(value), &self))?;
+
+                self.visit_str(variant)
+            }
+        }
+
+        impl<'de> DeserializeSeed<'de> for SourceTypeIdentifier {
+            type Value = SourceType;
+
+            fn deserialize<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                deserializer.deserialize_identifier(SourceTypeIdentifier)
+            }
+        }
+
+        struct SourceTypeEnum;
+
+        impl<'de> Visitor<'de> for SourceTypeEnum {
+            type Value = SourceType;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+                formatter.write_str("svd2rust source type")
+            }
+
+            fn visit_enum<A>(self, value: A) -> Result<Self::Value, A::Error>
+            where
+                A: EnumAccess<'de>,
+            {
+                let (ans, variant) = value.variant_seed(SourceTypeIdentifier)?;
+                // Every variant is a unit variant.
+                variant.unit_variant()?;
+                Ok(ans)
+            }
+        }
+
+        deserializer.deserialize_enum("SourceType", &SOURCE_TYPE_NAMES, SourceTypeEnum)
+    }
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -63,6 +63,9 @@ impl Default for Config {
     }
 }
 
+pub(crate) const TARGET_NAMES: [&'static str; 6] =
+    ["cortex-m", "msp430", "riscv", "xtensa-lx", "mips", "none"];
+
 #[allow(clippy::upper_case_acronyms)]
 #[allow(non_camel_case_types)]
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
@@ -94,6 +97,22 @@ impl Default for Target {
         Self::CortexM
     }
 }
+
+impl ToString for Target {
+    fn to_string(&self) -> String {
+        match self {
+            Target::CortexM => "cortex-m",
+            Target::Msp430 => "msp430",
+            Target::RISCV => "riscv",
+            Target::XtensaLX => "xtensa-lx",
+            Target::Mips => "mips",
+            Target::None => "none",
+        }
+        .to_string()
+    }
+}
+
+pub(crate) const SOURCE_TYPE_NAMES: [&'static str; 3] = ["xml", "yaml", "json"];
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum SourceType {
@@ -127,6 +146,19 @@ impl SourceType {
             .and_then(|e| e.to_str())
             .and_then(Self::from_extension)
             .unwrap_or_default()
+    }
+}
+
+impl ToString for SourceType {
+    fn to_string(&self) -> String {
+        match self {
+            SourceType::Xml => "xml",
+            #[cfg(feature = "yaml")]
+            SourceType::Yaml => "yaml",
+            #[cfg(feature = "json")]
+            SourceType::Json => "json",
+        }
+        .to_string()
     }
 }
 


### PR DESCRIPTION
This pull request updates dependency `clap` svd2rust binary from `2.0` to `4.0`.

It has been years since clap has more user friendly interfaces and more rich ecosystem around it. In this version, we adpot to modern `clap-verbosity-flag` to describe a log level (not `--log_level <LEVEL>`, but `-v`, `-vv` etc., see https://docs.rs/clap-verbosity-flag). The default cases of command lines is changed to kebab-case in modern clap 4.0, other than snake_case in older versions. Other than that, no changes to command line parameters as well as their help messages are applied in this pull request.

The crate `clap_conf` is written back to 2021 and lacks people to maintain. It's not good to use it in frequently used embedded Rust toolchain, I rewrote it with a `toml` and `serde` based toml file parser to adapt to older version toml based toolchain configurations. If this feature should not be used in the future, we may remove this part of code.

The command line helper after this pull request:

![图片](https://user-images.githubusercontent.com/40385009/195254045-22ef1650-9a6e-4c1e-b5d7-fe7a16707ff8.png)

No changes to library code is included in this pull request.

For reviewers: if this pull request would include any unacceptible breaking changes in command line, please note here and I will modify code in this pull request.