### PR TITLE
fix: remove lint #![deny(const_err)]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Update `clap` to 4.0, use `irx-config` instead of `clap_conf`
 - Add #[must_use] to prevent hanging field writers
-- remove explicit deref in `generic.rs` since it's done by auto-deref
+- Remove explicit deref in `generic.rs` since it's done by auto-deref
 - Make writing raw bits to a whole register safe if the SVD indicates
   so through the <WriteConstraint> element (see [v0.7.1] too).
+- Remove lint #![deny(const_err)] as it is a hard error in Rust now
 
 ## [v0.26.0] - 2022-10-07
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -52,7 +52,6 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
     if !config.make_mod {
         out.extend(quote! {
             // Deny a subset of warnings
-            #![deny(const_err)]
             #![deny(dead_code)]
             #![deny(improper_ctypes)]
             #![deny(missing_docs)]


### PR DESCRIPTION
This lint has been removed in Rust, see: #669 . We remove it here to avoid compile warnings.

Before this pull request, every peripheral access crate this software generates will emit following warning upon compilation:

```
warning: lint `const_err` has been removed: converted into hard error, see issue #71800 <https://github.com/rust-lang/rust/issues/71800> for more information
 --> src\lib.rs:3:9
  |
3 | #![deny(const_err)]
  |         ^^^^^^^^^
  |
  = note: `#[warn(renamed_and_removed_lints)]` on by default
```