### PR TITLE
Not cast if unnecessary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Don't cast fields with width 17-31 and non-zero offset.
+
 ## [v0.27.0] - 2022-10-24
 
 - Manually inline set/clear_bit

--- a/build.rs
+++ b/build.rs
@@ -35,7 +35,7 @@ fn commit_info() -> String {
 fn commit_hash() -> Result<String, IgnoredError> {
     Ok(String::from_utf8(
         Command::new("git")
-            .args(&["rev-parse", "--short", "HEAD"])
+            .args(["rev-parse", "--short", "HEAD"])
             .output()?
             .stdout,
     )?)
@@ -44,7 +44,7 @@ fn commit_hash() -> Result<String, IgnoredError> {
 fn commit_date() -> Result<String, IgnoredError> {
     Ok(String::from_utf8(
         Command::new("git")
-            .args(&["log", "-1", "--date=short", "--pretty=format:%cd"])
+            .args(["log", "-1", "--date=short", "--pretty=format:%cd"])
             .output()?
             .stdout,
     )?)

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -33,7 +33,7 @@ pub fn render(
         .map(|i| (i.0.value, (i.0, i.1, i.2)))
         .collect::<HashMap<_, _>>();
 
-    let mut interrupts = interrupts.into_iter().map(|(_, v)| v).collect::<Vec<_>>();
+    let mut interrupts = interrupts.into_values().collect::<Vec<_>>();
     interrupts.sort_by_key(|i| i.0.value);
 
     let mut root = TokenStream::new();

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -30,7 +30,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
     let span = Span::call_site();
     let name_str = name.to_sanitized_constant_case();
     let name_constant_case = Ident::new(&name_str, span);
-    let address = util::hex(p.base_address as u64);
+    let address = util::hex(p.base_address);
     let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
 
     let name_snake_case = name.to_snake_case_ident(span);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,7 +546,7 @@ pub fn generate(input: &str, config: &Config) -> Result<Generation> {
     let device = load_from(input, config)?;
     let mut device_x = String::new();
     let items =
-        generate::device::render(&device, config, &mut device_x).or(Err(SvdError::Render))?;
+        generate::device::render(&device, config, &mut device_x).map_err(|_| SvdError::Render)?;
 
     let mut lib_rs = String::new();
     writeln!(


### PR DESCRIPTION
In the previous PR #675, some cases of unnecessary casting are eliminated. However, if there is a big field (bigger than 16) with offset, there is still unnecessary generated casting. This PR fixes this case and adjusts the code according to clippy.