### PR TITLE
Fix generated code for MSP430 atomics

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
         # All generated code should be running on stable now
         rust: [stable]
 
+        # By default, target x86
+        target: [x86_64-unknown-linux-gnu]
+
         # All vendor files we want to test on stable
         vendor: [Atmel, Freescale, Fujitsu, GD32, Holtek, Microchip, Nordic, Nuvoton, NXP, RISC-V, SiliconLabs, Spansion, STMicro, Toshiba]
 
@@ -76,10 +79,12 @@ jobs:
           - rust: nightly
             vendor: MSP430
             options: all-nightly
+            target: msp430-none-elf
 
           - rust: nightly
             vendor: MSP430
             options: none
+            target: msp430-none-elf
 
           # Use nightly for architectures which don't support stable
           - rust: nightly
@@ -93,6 +98,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
+          target: ${{ matrix.target }}
 
       - name: Cache
         uses: Swatinem/rust-cache@v2
@@ -105,6 +111,7 @@ jobs:
         env:
           VENDOR: ${{ matrix.vendor }}
           OPTIONS: ${{ matrix.options }}
+          TARGET: ${{ matrix.target }}
           COMMAND: check
         run: bash ci/script.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,7 @@ jobs:
           profile: minimal
           toolchain: ${{ matrix.rust }}
           override: true
-          target: ${{ matrix.target }}
+          components: rust-src
 
       - name: Cache
         uses: Swatinem/rust-cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,12 @@ jobs:
 
           # Use nightly for architectures which don't support stable
           - rust: nightly
-            vendor: OTHER
+            vendor: MSP430
+            options: all-nightly
+
+          - rust: nightly
+            vendor: MSP430
+            options: none
 
           # Use nightly for architectures which don't support stable
           - rust: nightly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
           # Test MSRV
           - rust: 1.60.0
             vendor: Nordic
+            target: x86_64-unknown-linux-gnu
 
           # Use nightly for architectures which don't support stable
           - rust: nightly
@@ -89,6 +90,7 @@ jobs:
           # Use nightly for architectures which don't support stable
           - rust: nightly
             vendor: Espressif
+            target: x86_64-unknown-linux-gnu
 
     steps:
       - uses: actions/checkout@v3
@@ -139,6 +141,7 @@ jobs:
           VENDOR: RISC-V
           OPTIONS: all
           COMMAND: clippy
+          TARGET: x86_64-unknown-linux-gnu
         run: bash ci/script.sh
 
   ci-serde:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [v0.27.1] - 2022-10-25
 
-- fix cli error with --help/version
+- Fix cli error with --help/version
 - Don't cast fields with width 17-31 and non-zero offset.
+- Fix generated code for MSP430 atomics
 
 ## [v0.27.0] - 2022-10-24
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -15,7 +15,7 @@ test_svd() {
 
     popd
 
-    cargo $COMMAND --manifest-path $td/Cargo.toml
+    cargo $COMMAND --manifest-path $td/Cargo.toml --target $TARGET
 }
 
 test_svd_for_target() {
@@ -23,13 +23,13 @@ test_svd_for_target() {
 
     # NOTE we care about errors in svd2rust, but not about errors / warnings in rustfmt
     pushd $td
-    RUST_BACKTRACE=1 svd2rust $strict $const_generic $derive_more $nightly --target $1 -i input.svd
+    RUST_BACKTRACE=1 svd2rust $const_generic $derive_more $nightly --target $1 -i input.svd
 
     mv lib.rs src/lib.rs
 
     popd
 
-    cargo $COMMAND --manifest-path $td/Cargo.toml
+    cargo $COMMAND --manifest-path $td/Cargo.toml --target $TARGET
 }
 
 main() {

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -9,7 +9,7 @@ test_svd() {
 
     # NOTE we care about errors in svd2rust, but not about errors / warnings in rustfmt
     pushd $td
-    RUST_BACKTRACE=1 svd2rust $strict $const_generic $derive_more -i ${1}.svd
+    RUST_BACKTRACE=1 svd2rust $strict $const_generic $derive_more $nightly -i ${1}.svd
 
     mv lib.rs src/lib.rs
 
@@ -23,7 +23,7 @@ test_svd_for_target() {
 
     # NOTE we care about errors in svd2rust, but not about errors / warnings in rustfmt
     pushd $td
-    RUST_BACKTRACE=1 svd2rust --target $1 -i input.svd
+    RUST_BACKTRACE=1 svd2rust $strict $const_generic $derive_more $nightly --target $1 -i input.svd
 
     mv lib.rs src/lib.rs
 
@@ -40,30 +40,41 @@ main() {
     td=$(mktemp -d)
 
     case $OPTIONS in
+        all-nightly)
+            const_generic="--const_generic"
+            strict="--strict"
+            derive_more="--derive_more"
+            nightly="--nightly"
+            ;;
         all)
             const_generic="--const_generic"
             strict="--strict"
             derive_more="--derive_more"
+            nightly=""
             ;;
         strict)
             const_generic=""
             strict="--strict"
             derive_more=""
+            nightly=""
             ;;
         const)
             const_generic="--const_generic"
             strict=""
             derive_more=""
+            nightly=""
             ;;
         derive_more)
             const_generic=""
             strict=""
             derive_more="--derive_more"
+            nightly=""
             ;;
         *)
             const_generic=""
             strict=""
             derive_more=""
+            nightly=""
             ;;
     esac
 
@@ -489,13 +500,17 @@ main() {
             # test_svd LPC5410x_v0.4
         ;;
 
-        # test other targets (architectures)
-        OTHER)
+        # MSP430
+        MSP430)
             echo '[dependencies.msp430]' >> $td/Cargo.toml
-            echo 'version = "0.3.0"' >> $td/Cargo.toml
+            echo 'version = "0.4.0"' >> $td/Cargo.toml
+
+            echo '[dependencies.msp430-atomic]' >> $td/Cargo.toml
+            echo 'version = "0.1.4"' >> $td/Cargo.toml
 
             # Test MSP430
             test_svd_for_target msp430 https://raw.githubusercontent.com/pftbest/msp430g2553/v0.3.0-svd/msp430g2553.svd
+            test_svd_for_target msp430 https://raw.githubusercontent.com/YuhanLiin/msp430fr2355/rt-up/msp430fr2355.svd
         ;;
 
         # Community-provided RISC-V SVDs

--- a/src/generate/generic_msp430_atomic.rs
+++ b/src/generate/generic_msp430_atomic.rs
@@ -1,8 +1,7 @@
 use msp430_atomic::AtomicOperations;
 
-impl<REG: Writable> Reg<REG>
+impl<REG: Readable + Writable> Reg<REG>
 where
-    Self: Readable + Writable,
     REG::Ux: AtomicOperations + Default + core::ops::Not<Output = REG::Ux>,
 {
     /// Set high every bit in the register that was set in the write proxy. Leave other bits
@@ -10,12 +9,12 @@ where
     #[inline(always)]
     pub unsafe fn set_bits<F>(&self, f: F)
     where
-        F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+        F: FnOnce(&mut REG::Writer) -> &mut W<REG>,
     {
-        let bits = f(&mut W {
+        let bits = f(&mut REG::Writer::from(W {
             bits: Default::default(),
             _reg: marker::PhantomData,
-        })
+        }))
         .bits;
         REG::Ux::atomic_or(self.register.as_ptr(), bits);
     }
@@ -25,12 +24,12 @@ where
     #[inline(always)]
     pub unsafe fn clear_bits<F>(&self, f: F)
     where
-        F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+        F: FnOnce(&mut REG::Writer) -> &mut W<REG>,
     {
-        let bits = f(&mut W {
+        let bits = f(&mut REG::Writer::from(W {
             bits: !REG::Ux::default(),
             _reg: marker::PhantomData,
-        })
+        }))
         .bits;
         REG::Ux::atomic_and(self.register.as_ptr(), bits);
     }
@@ -40,12 +39,12 @@ where
     #[inline(always)]
     pub unsafe fn toggle_bits<F>(&self, f: F)
     where
-        F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+        F: FnOnce(&mut REG::Writer) -> &mut W<REG>,
     {
-        let bits = f(&mut W {
+        let bits = f(&mut REG::Writer::from(W {
             bits: Default::default(),
             _reg: marker::PhantomData,
-        })
+        }))
         .bits;
         REG::Ux::atomic_xor(self.register.as_ptr(), bits);
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -504,8 +504,8 @@
 //! ```ignore
 //! // These can be called from different contexts even though they are modifying the same register
 //! P1.p1out.set_bits(|w| unsafe { w.bits(1 << 1) });
-//! P1.p1out.clear(|w| unsafe { w.bits(!(1 << 2)) });
-//! P1.p1out.toggle(|w| unsafe { w.bits(1 << 4) });
+//! P1.p1out.clear_bits(|w| unsafe { w.bits(!(1 << 2)) });
+//! P1.p1out.toggle_bits(|w| unsafe { w.bits(1 << 4) });
 //! ```
 #![recursion_limit = "128"]
 


### PR DESCRIPTION
The current generated code for MSP430 atomics is not compatible with the rest of the generated code. This PR fixes this.