### PR TITLE
Compare contents before deriving

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Test patched STM32
 - simplify ci strategy
 - Fix generated code for MSP430 atomics
-- Add handling for disjoint arrays
+- Add handling for disjoint register arrays and validation of derives
 
 ## [v0.27.1] - 2022-10-25
 


### PR DESCRIPTION
Closes #660. Compares register properties and fields of regex-matched register names to decide if implicitly deriving is possible. I could use some help with the CI integration for vendor Renesas. See [ra-rs/ra](https://github.com/ra-rs/ra) for SVDs.