### PR TITLE
fix docs

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -49,7 +49,7 @@ pub trait RegisterSpec {
 
 /// Trait implemented by readable registers to enable the `read` method.
 ///
-/// Registers marked with `Writable` can be also `modify`'ed.
+/// Registers marked with `Writable` can be also be `modify`'ed.
 pub trait Readable: RegisterSpec {
     /// Result from a call to `read` and argument to `modify`.
     type Reader: From<R<Self>> + core::ops::Deref<Target = R<Self>>;
@@ -59,7 +59,7 @@ pub trait Readable: RegisterSpec {
 ///
 /// This enables the  `write`, `write_with_zero` and `reset` methods.
 ///
-/// Registers marked with `Readable` can be also `modify`'ed.
+/// Registers marked with `Readable` can be also be `modify`'ed.
 pub trait Writable: RegisterSpec {
     /// Writer type argument to `write`, et al.
     type Writer: From<W<Self>> + core::ops::DerefMut<Target = W<Self>>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -170,7 +170,7 @@
 //! To use a peripheral first you must get an *instance* of the peripheral. All the device
 //! peripherals are modeled as singletons (there can only ever be, at most, one instance of any
 //! one of them) and the only way to get an instance of them is through the `Peripherals::take`
-//! method.
+//! method, enabled via the `critical-section` feature on the generated crate.
 //!
 //! ```ignore
 //! let mut peripherals = stm32f30x::Peripherals::take().unwrap();


### PR DESCRIPTION
touches on #699

- make it clear how to enable the `take` method
- fix minor typo
