### PR TITLE
Fix dangling implicit derives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
+- Fix dangling implicit derives
 
 ## [v0.28.0] - 2022-12-25
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -859,7 +859,7 @@ fn compare_this_against_prev(
     Ok(None)
 }
 
-/// Compare the given type name against previous regexs, then inspect fields
+/// Compare previous type names against the given regex, then inspect fields
 fn compare_prev_against_this(
     reg: &MaybeArray<RegisterInfo>,
     ty_name: &str,
@@ -911,6 +911,21 @@ fn compare_prev_against_this(
                     if my_derive_info != loop_derive_info {
                         my_derive_info = loop_derive_info;
                     }
+                }
+            }
+            if let DeriveInfo::Implicit(my_rpath) = &my_derive_info {
+                match prev_derive_info {
+                    DeriveInfo::Implicit(their_rpath) => {
+                        if their_rpath.name == ty_name {
+                            (_, *their_rpath) = find_root(&my_rpath.name, path, index)?;
+                        }
+                    }
+                    DeriveInfo::Explicit(their_rpath) => {
+                        if their_rpath.name == ty_name {
+                            (_, *their_rpath) = find_root(&my_rpath.name, path, index)?;
+                        }
+                    }
+                    _ => {}
                 }
             }
         }


### PR DESCRIPTION
While working on R7FA6M5BH.svd I found that the generated code does not compile because P0%sPFS_BY got thrown away while implicitly deriving registers. Looking through the debug log I found this:
```
[DEBUG svd2rust::generate::device] Rendering peripheral PFS
[DEBUG svd2rust::generate::peripheral] Checking derivation information
[DEBUG svd2rust::generate::peripheral] register P009PFS_BY implicitly derives from P00%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P010PFS implicitly derives from P0%sPFS
[DEBUG svd2rust::generate::peripheral] register P010PFS_HA implicitly derives from P0%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register P010PFS_BY implicitly derives from P0%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P0%sPFS_BY implicitly derives from P00%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P200PFS implicitly derives from P20%sPFS
[DEBUG svd2rust::generate::peripheral] register P200PFS_HA implicitly derives from P20%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register P200PFS_BY implicitly derives from P20%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P2%sPFS implicitly derives from P20%sPFS
[DEBUG svd2rust::generate::peripheral] register P2%sPFS_HA implicitly derives from P20%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register P2%sPFS_BY implicitly derives from P20%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P70%sPFS implicitly derives from P70%sPFS
[DEBUG svd2rust::generate::peripheral] register P70%sPFS_HA implicitly derives from P70%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register P70%sPFS_BY implicitly derives from P70%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P90%sPFS implicitly derives from P90%sPFS
[DEBUG svd2rust::generate::peripheral] register P90%sPFS_HA implicitly derives from P90%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register P90%sPFS_BY implicitly derives from P90%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register PA0%sPFS implicitly derives from PA0%sPFS
[DEBUG svd2rust::generate::peripheral] register PA0%sPFS_HA implicitly derives from PA0%sPFS_HA
[DEBUG svd2rust::generate::peripheral] register PA0%sPFS_BY implicitly derives from PA0%sPFS_BY
[DEBUG svd2rust::generate::peripheral] register P%sSAR implicitly derives from P%sSAR
[DEBUG svd2rust::generate::peripheral] Pushing cluster & register information into output
[DEBUG svd2rust::generate::peripheral] Pushing 95 register or cluster blocks into output
```
P010PFS_BY implicitly derives from P0%sPFS_BY and P0%sPFS_BY implicitly derives from P00%sPFS_BY, which leaves P0%sPFS_BY dangling (P0%sPFS_BY regex matched to P009PFS_BY and implicitly derived from the root P00%sPFS_BY). The fix checks for would-be dangling derives while checking previous names against the "P0%sPFS_BY" regex, and replaces the derive with the new root.