### PR TITLE
Add `steal()` for each peripheral.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fix dangling implicit derives
 - Fix escaping <> and & characters in doc attributes
 - Add `interrupt_link_section` config parameter for controlling the `#[link_section = "..."]` attribute of `__INTERRUPTS`
+- Add `steal()` for each peripheral
 
 ## [v0.28.0] - 2022-12-25
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -92,6 +92,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                             Self::PTR
                         }
 
+                        ///Steal an instance of this peripheral
                         pub unsafe fn steal(&self) -> Self {
                             Self { _marker: PhantomData }
                         }
@@ -155,6 +156,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         Self::PTR
                     }
 
+                    ///Steal an instance of this peripheral
                     pub unsafe fn steal(&self) -> Self {
                         Self { _marker: PhantomData }
                     }

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -91,6 +91,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         pub const fn ptr() -> *const #base::RegisterBlock {
                             Self::PTR
                         }
+
+                        pub unsafe fn steal(&self) -> Self {
+                            Self { _marker: PhantomData }
+                        }
                     }
 
                     #feature_attribute_n
@@ -149,6 +153,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                     #[inline(always)]
                     pub const fn ptr() -> *const #base::RegisterBlock {
                         Self::PTR
+                    }
+
+                    pub unsafe fn steal(&self) -> Self {
+                        Self { _marker: PhantomData }
                     }
                 }
 


### PR DESCRIPTION
This is more convenient than the `Peripherals::steal()`