### PR TITLE
feat: configurable link section attribute for irqs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Optimize case change/sanitize
 - Fix dangling implicit derives
 - Fix escaping <> and & characters in doc attributes
+- Add `interrupt_link_section` config parameter for controlling the `#[link_section = "..."]` attribute of `__INTERRUPTS`
 
 ## [v0.28.0] - 2022-12-25
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -188,13 +188,11 @@ pub fn render(
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);")?;
             }
 
-            let link_section_attr = if let Some(section) = &config.interrupt_link_section {
+            let link_section_attr = config.interrupt_link_section.as_ref().map(|section| {
                 quote! {
                     #[link_section = #section]
                 }
-            } else {
-                quote! {}
-            };
+            });
 
             root.extend(quote! {
                 #[cfg(feature = "rt")]
@@ -222,13 +220,11 @@ pub fn render(
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);")?;
             }
 
-            let link_section_attr = if let Some(section) = &config.interrupt_link_section {
+            let link_section_attr = config.interrupt_link_section.as_ref().map(|section| {
                 quote! {
                     #[link_section = #section]
                 }
-            } else {
-                quote! {}
-            };
+            });
 
             root.extend(quote! {
                 #[cfg(feature = "rt")]

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -118,6 +118,14 @@ pub fn render(
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);")?;
             }
 
+            let link_section_name = config
+                .interrupt_link_section
+                .as_deref()
+                .unwrap_or(".vector_table.interrupts");
+            let link_section_attr = quote! {
+                #[link_section = #link_section_name]
+            };
+
             root.extend(quote! {
                 #[cfg(feature = "rt")]
                 extern "C" {
@@ -132,7 +140,7 @@ pub fn render(
 
                 #[cfg(feature = "rt")]
                 #[doc(hidden)]
-                #[link_section = ".vector_table.interrupts"]
+                #link_section_attr
                 #[no_mangle]
                 pub static __INTERRUPTS: [Vector; #n] = [
                     #elements
@@ -143,6 +151,14 @@ pub fn render(
             for name in &names {
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);").unwrap();
             }
+
+            let link_section_name = config
+                .interrupt_link_section
+                .as_deref()
+                .unwrap_or(".vector_table.interrupts");
+            let link_section_attr = quote! {
+                #[link_section = #link_section_name]
+            };
 
             root.extend(quote! {
                 #[cfg(feature = "rt")]
@@ -158,7 +174,7 @@ pub fn render(
 
                 #[cfg(feature = "rt")]
                 #[doc(hidden)]
-                #[link_section = ".vector_table.interrupts"]
+                #link_section_attr
                 #[no_mangle]
                 #[used]
                 pub static __INTERRUPTS:
@@ -171,6 +187,14 @@ pub fn render(
             for name in &names {
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);")?;
             }
+
+            let link_section_attr = if let Some(section) = &config.interrupt_link_section {
+                quote! {
+                    #[link_section = #section]
+                }
+            } else {
+                quote! {}
+            };
 
             root.extend(quote! {
                 #[cfg(feature = "rt")]
@@ -186,6 +210,7 @@ pub fn render(
 
                 #[cfg(feature = "rt")]
                 #[doc(hidden)]
+                #link_section_attr
                 #[no_mangle]
                 pub static __EXTERNAL_INTERRUPTS: [Vector; #n] = [
                     #elements
@@ -196,6 +221,14 @@ pub fn render(
             for name in &names {
                 writeln!(device_x, "PROVIDE({name} = DefaultHandler);")?;
             }
+
+            let link_section_attr = if let Some(section) = &config.interrupt_link_section {
+                quote! {
+                    #[link_section = #section]
+                }
+            } else {
+                quote! {}
+            };
 
             root.extend(quote! {
                 #[cfg(feature = "rt")]
@@ -210,6 +243,7 @@ pub fn render(
                 }
 
                 #[cfg(feature = "rt")]
+                #link_section_attr
                 #[doc(hidden)]
                 pub static __INTERRUPTS: [Vector; #n] = [
                     #elements

--- a/src/util.rs
+++ b/src/util.rs
@@ -59,6 +59,8 @@ pub struct Config {
     pub source_type: SourceType,
     #[cfg_attr(feature = "serde", serde(default))]
     pub log_level: Option<String>,
+    #[cfg_attr(feature = "serde", serde(default))]
+    pub interrupt_link_section: Option<String>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -120,6 +122,7 @@ impl Default for Config {
             input: None,
             source_type: SourceType::default(),
             log_level: None,
+            interrupt_link_section: None,
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -232,7 +232,7 @@ pub trait ToSanitizedCase {
 impl ToSanitizedCase for str {
     fn to_sanitized_pascal_case(&self) -> Cow<str> {
         let s = Case::Pascal.sanitize(self);
-        if s.as_bytes().get(0).unwrap_or(&0).is_ascii_digit() {
+        if s.as_bytes().first().unwrap_or(&0).is_ascii_digit() {
             Cow::from(format!("_{}", s))
         } else {
             s
@@ -240,7 +240,7 @@ impl ToSanitizedCase for str {
     }
     fn to_sanitized_constant_case(&self) -> Cow<str> {
         let s = Case::Constant.sanitize(self);
-        if s.as_bytes().get(0).unwrap_or(&0).is_ascii_digit() {
+        if s.as_bytes().first().unwrap_or(&0).is_ascii_digit() {
             Cow::from(format!("_{}", s))
         } else {
             s
@@ -250,7 +250,7 @@ impl ToSanitizedCase for str {
         const INTERNALS: [&str; 4] = ["set_bit", "clear_bit", "bit", "bits"];
 
         let s = Case::Snake.sanitize(self);
-        if s.as_bytes().get(0).unwrap_or(&0).is_ascii_digit() {
+        if s.as_bytes().first().unwrap_or(&0).is_ascii_digit() {
             format!("_{}", s).into()
         } else if INTERNALS.contains(&s.as_ref()) {
             s + "_"


### PR DESCRIPTION
This change introduces a new config field that allows `svd2rust` to target which linker sections get assigned to the `__INTERRUPTS` static, with reasonable defaults.

Previously on RISC-V, the choice was always left up to the compiler, and it seemed to always pick `.rodata`. Unfortunately, in my context, that meant placing the LUT in a memory range that had a lot of highly variable latency, which cost not just time but predictability in servicing interrupts.

With this change in place, I'm able to target a particular section (e.g. `.data`, or `.trap.rodata`) for the placement of the static, which grants more granular control over the ultimate loaded memory address.

For the full details about the problem, please see: https://github.com/esp-rs/esp-hal/pull/534/commits/e29f3d547dc210e1b73313be6053a2122239a467