### PR TITLE
Add steal() for each peripheral.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - removed register writer & reader wrappers, generic `REG` in field writers (#731)
 - Updated syn to version 2 (#732)
 - Let readable field fetch doc from svd description (#734)
+- Add `steal()` for each peripheral
 
 ## [v0.29.0] - 2023-06-05
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -53,6 +53,25 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
         feature_attribute.extend(quote! { #[cfg(feature = #feature_name)] });
     };
 
+    let steal_fn = quote! {
+        /// Steal an instance of this peripheral
+        ///
+        /// # Safety
+        ///
+        /// Ensure that the new instance of the peripheral cannot be used in a way
+        /// that may race with any existing instances, for example by only
+        /// accessing read-only or write-only registers, or by consuming the
+        /// original peripheral and using critical sections to coordinate
+        /// access between multiple new instances.
+        ///
+        /// Additionally, other software such as HALs may rely on only one
+        /// peripheral instance existing to ensure memory safety; ensure
+        /// no stolen instances are passed to such software.
+        pub unsafe fn steal() -> Self {
+            Self { _marker: PhantomData }
+        }
+    };
+
     match &p {
         Peripheral::Array(p, dim) => {
             let names: Vec<Cow<str>> = names(p, dim).map(|n| n.into()).collect();
@@ -92,22 +111,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                             Self::PTR
                         }
 
-                        ///Steal an instance of this peripheral
-                        ///
-                        ///# Safety
-                        ///
-                        /// Ensure that the new instance of the peripheral cannot be used in a way
-                        /// that may race with any existing instances, for example by only
-                        /// accessing read-only or write-only registers, or by consuming the
-                        /// original peripheral and using critical sections to coordinate
-                        /// access between multiple new instances.
-                        ///
-                        /// Additionally, other software such as HALs may rely on only one
-                        /// peripheral instance existing to ensure memory safety; ensure
-                        /// no stolen instances are passed to such software.
-                        pub unsafe fn steal() -> Self {
-                            Self { _marker: PhantomData }
-                        }
+                        #steal_fn
                     }
 
                     #feature_attribute_n
@@ -168,22 +172,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         Self::PTR
                     }
 
-                    ///Steal an instance of this peripheral
-                    ///
-                    ///# Safety
-                    ///
-                    /// Ensure that the new instance of the peripheral cannot be used in a way
-                    /// that may race with any existing instances, for example by only
-                    /// accessing read-only or write-only registers, or by consuming the
-                    /// original peripheral and using critical sections to coordinate
-                    /// access between multiple new instances.
-                    ///
-                    /// Additionally, other software such as HALs may rely on only one
-                    /// peripheral instance existing to ensure memory safety; ensure
-                    /// no stolen instances are passed to such software.
-                    pub unsafe fn steal() -> Self {
-                        Self { _marker: PhantomData }
-                    }
+                    #steal_fn
                 }
 
                 #feature_attribute

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -93,7 +93,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         }
 
                         ///Steal an instance of this peripheral
-                        pub unsafe fn steal(&self) -> Self {
+                        pub unsafe fn steal() -> Self {
                             Self { _marker: PhantomData }
                         }
                     }
@@ -157,7 +157,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                     }
 
                     ///Steal an instance of this peripheral
-                    pub unsafe fn steal(&self) -> Self {
+                    pub unsafe fn steal() -> Self {
                         Self { _marker: PhantomData }
                     }
                 }

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -93,6 +93,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         }
 
                         ///Steal an instance of this peripheral
+                        ///
+                        ///# Safety
+                        ///
+                        ///Make sure that [`Peripherals::steal`] is already called
                         pub unsafe fn steal() -> Self {
                             Self { _marker: PhantomData }
                         }
@@ -157,6 +161,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                     }
 
                     ///Steal an instance of this peripheral
+                        ///
+                        ///# Safety
+                        ///
+                        ///Make sure that [`Peripherals::steal`] is already called
                     pub unsafe fn steal() -> Self {
                         Self { _marker: PhantomData }
                     }

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -92,6 +92,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                             Self::PTR
                         }
 
+                        ///Steal an instance of this peripheral
                         pub unsafe fn steal(&self) -> Self {
                             Self { _marker: PhantomData }
                         }
@@ -155,6 +156,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         Self::PTR
                     }
 
+                    ///Steal an instance of this peripheral
                     pub unsafe fn steal(&self) -> Self {
                         Self { _marker: PhantomData }
                     }

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -91,6 +91,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         pub const fn ptr() -> *const #base::RegisterBlock {
                             Self::PTR
                         }
+
+                        pub unsafe fn steal(&self) -> Self {
+                            Self { _marker: PhantomData }
+                        }
                     }
 
                     #feature_attribute_n
@@ -149,6 +153,10 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                     #[inline(always)]
                     pub const fn ptr() -> *const #base::RegisterBlock {
                         Self::PTR
+                    }
+
+                    pub unsafe fn steal(&self) -> Self {
+                        Self { _marker: PhantomData }
                     }
                 }
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -96,7 +96,15 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                         ///
                         ///# Safety
                         ///
-                        ///Make sure that [`Peripherals::steal`] is already called
+                        /// Ensure that the new instance of the peripheral cannot be used in a way
+                        /// that may race with any existing instances, for example by only
+                        /// accessing read-only or write-only registers, or by consuming the
+                        /// original peripheral and using critical sections to coordinate
+                        /// access between multiple new instances.
+                        ///
+                        /// Additionally, other software such as HALs may rely on only one
+                        /// peripheral instance existing to ensure memory safety; ensure
+                        /// no stolen instances are passed to such software.
                         pub unsafe fn steal() -> Self {
                             Self { _marker: PhantomData }
                         }
@@ -161,10 +169,18 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                     }
 
                     ///Steal an instance of this peripheral
-                        ///
-                        ///# Safety
-                        ///
-                        ///Make sure that [`Peripherals::steal`] is already called
+                    ///
+                    ///# Safety
+                    ///
+                    /// Ensure that the new instance of the peripheral cannot be used in a way
+                    /// that may race with any existing instances, for example by only
+                    /// accessing read-only or write-only registers, or by consuming the
+                    /// original peripheral and using critical sections to coordinate
+                    /// access between multiple new instances.
+                    ///
+                    /// Additionally, other software such as HALs may rely on only one
+                    /// peripheral instance existing to ensure memory safety; ensure
+                    /// no stolen instances are passed to such software.
                     pub unsafe fn steal() -> Self {
                         Self { _marker: PhantomData }
                     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,9 +186,9 @@
 //! use the implementation provided by the target crate like `cortex-m`, `riscv` and `*-hal` crates.
 //! See more details in the [`critical-section`](https://crates.io/crates/critical-section) crate documentation.
 //!
-//! The singleton property can be *unsafely* bypassed using the `ptr` static method which is
-//! available on all the peripheral types. This method is useful for implementing safe higher
-//! level abstractions.
+//! The singleton property can be *unsafely* bypassed using the `ptr` or `steal` static methods
+//! which are available on all the peripheral types. This method is useful for implementing safe
+//! higher level abstractions.
 //!
 //! ```ignore
 //! struct PA0 { _0: () }


### PR DESCRIPTION
This is more convenient than the `Peripherals::steal()`