### PR TITLE
No longer set DEVICE_PERIPHERALS in steal()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - removed register writer & reader wrappers, generic `REG` in field writers (#731)
 - Updated syn to version 2 (#732)
 - Let readable field fetch doc from svd description (#734)
+- No longer set `DEVICE_PERIPHERALS` in `Peripherals::steal()`
 
 ## [v0.29.0] - 2023-06-05
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -311,12 +311,16 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
                 critical_section::with(|_| {
                     // SAFETY: We are in a critical section, so we have exclusive access
                     // to `DEVICE_PERIPHERALS`.
-                    if unsafe { DEVICE_PERIPHERALS } {
-                        return None
+                    unsafe {
+                        if DEVICE_PERIPHERALS {
+                            return None
+                        }
+                        DEVICE_PERIPHERALS = true;
                     }
 
-                    // SAFETY: `DEVICE_PERIPHERALS` is set to `true` by `Peripherals::steal`,
-                    // ensuring the peripherals can only be returned once.
+
+                    // SAFETY: `DEVICE_PERIPHERALS` is set to `true`,
+                    // ensuring the peripherals can only be safely returned once.
                     Some(unsafe { Peripherals::steal() })
                 })
             }
@@ -328,8 +332,6 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             /// Each of the returned peripherals must be used at most once.
             #[inline]
             pub unsafe fn steal() -> Self {
-                DEVICE_PERIPHERALS = true;
-
                 Peripherals {
                     #exprs
                 }


### PR DESCRIPTION
We've discussed this a bit in the weekly meetings, I propose removing setting `DEVICE_PERIPHERALS` from `steal()` and leave it only in `take()`. This shouldn't meaningfully change the safety conditions or the use of either API, but does make stealing zero-cost. It was always possible to unsafely `transmute()` to obtain `Peripherals` without setting `DEVICE_PERIPHERALS`, so I'm interested if anyone can remember why this existed in the first place or if it is indeed still needed.