### PR TITLE
shorter names for constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Shorter names for `Writable` trait constants
+
 ## [v0.30.2] - 2023-10-22
 
 - Fix documentation warnings
@@ -816,8 +818,7 @@ peripheral.register.write(|w| w.field().set());
 
 - Initial version of the `svd2rust` tool
 
-[Unreleased]: https://github.com/rust-embedded/svd2rust/compare/v0.30.2...HEAD
-[v0.30.2]: https://github.com/rust-embedded/svd2rust/compare/v0.30.1...v0.30.2
+[Unreleased]: https://github.com/rust-embedded/svd2rust/compare/v0.30.1...HEAD
 [v0.30.1]: https://github.com/rust-embedded/svd2rust/compare/v0.30.0...v0.30.1
 [v0.30.0]: https://github.com/rust-embedded/svd2rust/compare/v0.29.0...v0.30.0
 [v0.29.0]: https://github.com/rust-embedded/svd2rust/compare/v0.28.0...v0.29.0

--- a/src/generate/array_proxy.rs
+++ b/src/generate/array_proxy.rs
@@ -12,13 +12,13 @@ pub struct ArrayProxy<T, const COUNT: usize, const STRIDE: usize> {
     /// As well as providing a PhantomData, this field is non-public, and
     /// therefore ensures that code outside of this module can never create
     /// an ArrayProxy.
-    _array: marker::PhantomData<T>,
+    _array: Marker<T>,
 }
 #[allow(clippy::len_without_is_empty)]
 impl<T, const C: usize, const S: usize> ArrayProxy<T, C, S> {
     /// Get a reference from an [ArrayProxy] with no bounds checking.
     pub const unsafe fn get_ref(&self, index: usize) -> &T {
-        &*(self as *const Self).cast::<u8>().add(S * index).cast::<T>()
+        &*(self as *const Self).cast::<u8>().add(S * index).cast()
     }
     /// Get a reference from an [ArrayProxy], or return `None` if the index
     /// is out of bounds.

--- a/src/generate/generic_atomic.rs
+++ b/src/generate/generic_atomic.rs
@@ -54,7 +54,7 @@ mod atomic {
         {
             let bits = f(&mut W {
                 bits: Default::default(),
-                _reg: marker::PhantomData,
+                _reg: Marker,
             })
             .bits;
             REG::Ux::atomic_or(self.register.as_ptr(), bits);
@@ -73,7 +73,7 @@ mod atomic {
         {
             let bits = f(&mut W {
                 bits: !REG::Ux::default(),
-                _reg: marker::PhantomData,
+                _reg: Marker,
             })
             .bits;
             REG::Ux::atomic_and(self.register.as_ptr(), bits);
@@ -92,7 +92,7 @@ mod atomic {
         {
             let bits = f(&mut W {
                 bits: Default::default(),
-                _reg: marker::PhantomData,
+                _reg: Marker,
             })
             .bits;
             REG::Ux::atomic_xor(self.register.as_ptr(), bits);

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -420,8 +420,8 @@ pub fn render_register_mod(
         mod_items.extend(quote! {
             #[doc = #doc]
             impl crate::Writable for #regspec_ident {
-                const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = #zero_to_modify_fields_bitmap;
-                const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = #one_to_modify_fields_bitmap;
+                const ZEROS_BITMAP: Self::Ux = #zero_to_modify_fields_bitmap;
+                const ONES_BITMAP: Self::Ux = #one_to_modify_fields_bitmap;
             }
         });
     }


### PR DESCRIPTION
~~Due to less lines in `write` and `modify` this potentially leads to smaller size of debug builds.~~

cc @kossnikita Test this also, please.