### PR TITLE
support of default enum value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - `FieldWriter` takes offset as struct field instead of const generic.
   Improves SVD field array access
   Add `width`, `offset` methods
-- *breaking change* Always numerates field arrays from 0 
+- *breaking change* Always numerates field arrays from 0
+- Support of default value for `EnumeratedValues`
 
 ## [v0.30.3] - 2023-11-19
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -423,18 +423,18 @@ checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
 name = "serde"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bca2a08484b285dcb282d0f67b26cadc0df8b19f8c12502c13d966bf9482f001"
+checksum = "25dd9975e68d0cb5aa1120c288333fc98731bd1dd12f561e468ea4728c042b89"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.192"
+version = "1.0.193"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c7207fbec9faa48073f3e3074cbe553af6ea512d7c21ba46e434e70ea9fbc1"
+checksum = "43576ca501357b9b071ac53cdc7da8ef0cbd9493d8df094cd821777ea6e894d3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -494,9 +494,9 @@ dependencies = [
 
 [[package]]
 name = "svd-rs"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35830f227d0ee528eb674429091ba11781fbf141e72a87a9bc9c732522798b33"
+checksum = "dc56f34e2a3669bf718f48138273d66f98ab863ae5db5e3e3b291977f53025f4"
 dependencies = [
  "once_cell",
  "regex",
@@ -626,9 +626,9 @@ checksum = "f28467d3e1d3c6586d8f25fa243f544f5800fec42d97032474e17222c2b75cfa"
 
 [[package]]
 name = "utf8-width"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5190c9442dcdaf0ddd50f37420417d219ae5261bbf5db120d0f9bab996c9cba1"
+checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,7 +64,7 @@ version = "0.14.3"
 
 [dependencies.svd-rs]
 features = ["serde"]
-version = "0.14.4"
+version = "0.14.5"
 
 [dependencies.syn]
 version = "2.0"

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -81,7 +81,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                 let name = &pi.name;
                 let description = pi.description.as_deref().unwrap_or(&p.name);
                 let name_str = name.to_sanitized_constant_case();
-                let name_constant_case = Ident::new(&name, span);
+                let name_constant_case = Ident::new(name, span);
                 let address = util::hex(pi.base_address);
                 let p_snake = name.to_sanitized_snake_case();
                 snake_names.push(p_snake.to_string());


### PR DESCRIPTION
Closes #172

This is usefull for (reading) fields like this:
![изображение](https://github.com/rust-embedded/svd2rust/assets/3072754/209687ec-dbf2-44df-8bfc-b5e0ca931d4c)

For such fields changes look like:
![изображение](https://github.com/rust-embedded/svd2rust/assets/3072754/3268a604-25f3-4ddf-bd54-d90bdf49cd72)
![изображение](https://github.com/rust-embedded/svd2rust/assets/3072754/7f8765ff-8b36-4943-97f2-80ce2bd7243c)

