### PR TITLE
Remove ref in ArrayElemAccessor to solve the `needless_borrow` warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Remove needless reference in `ArrayElemAccessor`
+
 ## [v0.31.0] - 2023-11-24
 
 - Use methods to access any register or cluster

--- a/src/generate/peripheral/accessor.rs
+++ b/src/generate/peripheral/accessor.rs
@@ -204,7 +204,7 @@ impl ToTokens for ArrayElemAccessor {
             #[doc = #doc]
             #[inline(always)]
             pub const fn #name(&self) -> &#ty {
-                &self.#basename(#i)
+                self.#basename(#i)
             }
         }
         .to_tokens(tokens);


### PR DESCRIPTION
**TLDR**: This PR contains 1 commit:

1. remove ref (`&`) in `ArrayElemAccessor` to solve the `needless_borrow` warning

---

Currently, the generated code contains two parts:

1. `RawArrayAccessor` takes an argument `n` and returns ref
2. `ArrayElemAccessor` wraps `RawArrayAccessor`

```rust
// An example of generated code
#[doc = "0x58..0x74 - EMAC MAC Address High Register"]
#[inline(always)]
pub const fn emac_addr_high(&self, n: usize) -> &EMAC_ADDR_HIGH {
    #[allow(clippy::no_effect)]
    [(); 7][n];
    unsafe { &*(self as *const Self).cast::<u8>().add(88).add(8 * n).cast() }
}
#[doc = "0x58 - EMAC MAC Address High Register"]
#[inline(always)]
pub const fn emac_addr_high1(&self) -> &EMAC_ADDR_HIGH {
    &self.emac_addr_high(0)
}
```

It is needless to use `&` in `emac_addr_high1`.

**Consideration**

I haven't checked whether there is another situation that `ArrayElemAccessor` needs `&`. If so, this PR can be adjusted to ignore clippy warning.