### PR TITLE
Beautify error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 - Add iterators for register/cluster/field arrays
 - Use parentheses instead of square brackets in docs for field arrays
+- Better display parsing errors
 
 ## [v0.31.1] - 2023-11-27
 

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -671,22 +671,15 @@ fn expand(
         match &erc {
             RegisterCluster::Register(register) => {
                 let reg_name = &register.name;
-                let expanded_reg =
-                    expand_register(register, derive_info, config).with_context(|| {
-                        let descrip = register.description.as_deref().unwrap_or("No description");
-                        format!(
-                            "Error expanding register\nName: {reg_name}\nDescription: {descrip}"
-                        )
-                    })?;
+                let expanded_reg = expand_register(register, derive_info, config)
+                    .with_context(|| format!("can't expand register '{reg_name}'"))?;
                 trace!("Register: {reg_name}");
                 ercs_expanded.extend(expanded_reg);
             }
             RegisterCluster::Cluster(cluster) => {
                 let cluster_name = &cluster.name;
-                let expanded_cluster = expand_cluster(cluster, config).with_context(|| {
-                    let descrip = cluster.description.as_deref().unwrap_or("No description");
-                    format!("Error expanding cluster\nName: {cluster_name}\nDescription: {descrip}")
-                })?;
+                let expanded_cluster = expand_cluster(cluster, config)
+                    .with_context(|| format!("can't expand cluster '{cluster_name}'"))?;
                 trace!("Cluster: {cluster_name}");
                 ercs_expanded.extend(expanded_cluster);
             }
@@ -1359,13 +1352,8 @@ fn render_ercs(
                     }
                 }
                 let reg_name = &reg.name;
-                let rendered_reg =
-                    register::render(reg, path, rpath, index, config).with_context(|| {
-                        let descrip = reg.description.as_deref().unwrap_or("No description");
-                        format!(
-                            "Error rendering register\nName: {reg_name}\nDescription: {descrip}"
-                        )
-                    })?;
+                let rendered_reg = register::render(reg, path, rpath, index, config)
+                    .with_context(|| format!("can't render register '{reg_name}'"))?;
                 mod_items.extend(rendered_reg)
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -578,7 +578,7 @@ pub enum SvdError {
     #[error("Cannot format crate")]
     Fmt,
     #[error("Cannot render SVD device")]
-    Render,
+    Render(#[from] anyhow::Error),
 }
 
 /// Generates rust code for the specified svd content.
@@ -588,7 +588,7 @@ pub fn generate(input: &str, config: &Config) -> Result<Generation> {
     let device = load_from(input, config)?;
     let mut device_x = String::new();
     let items =
-        generate::device::render(&device, config, &mut device_x).map_err(|_| SvdError::Render)?;
+        generate::device::render(&device, config, &mut device_x).map_err(SvdError::Render)?;
 
     let mut lib_rs = String::new();
     writeln!(


### PR DESCRIPTION
I had a problem in my SVD file, but I got quite non-specific error: 'Cannot render SVD device'. In order to debug I rewrote error messages to understand the problem. Now it looks like this:

```
called `Result::unwrap()` on an `Err` value: Cannot render SVD device

Caused by:
    0: can't render peripheral 'FortiMac', group 'No group name'
    1: can't render register 'HASH'
    2: can't convert 512 bits into a Rust integral type
```