### PR TITLE
generic safe/unsafe W::bits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Bump MSRV to 1.74
+- generic unsafe `W::bits` + safe `W::set`
 - Add `base-address-shift` config flag
 - Fix case changing bugs, add `--ident-format` (`-f`) option flag
 


### PR DESCRIPTION
**breaking change**
mark `Writable` register with `Safety` marker.

makes `W::bits` always `unsafe` and always present

add safe `W::set` (other name?) synonym for `W::bits`. 