### PR TITLE
Add `base-address-shift` configuration flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Add `base-address-shift` config flag
+
 ## [v0.31.5] - 2024-01-04
 
 - `move` in `RegisterBlock::reg_iter` implementation (iterator of register/cluster array)

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,6 +28,7 @@ pub struct Config {
     pub reexport_core_peripherals: bool,
     pub reexport_interrupt: bool,
     pub ident_formats: IdentFormats,
+    pub base_address_shift: u64,
 }
 
 #[allow(clippy::upper_case_acronyms)]

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -40,7 +40,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
     let span = Span::call_site();
     let p_ty = ident(&name, &config.ident_formats.peripheral, span);
     let name_str = p_ty.to_string();
-    let address = util::hex(p.base_address);
+    let address = util::hex(p.base_address + config.base_address_shift);
     let description = util::respace(p.description.as_ref().unwrap_or(&p.name));
 
     let mod_ty = name.to_snake_case_ident(span);
@@ -83,7 +83,7 @@ pub fn render(p_original: &Peripheral, index: &Index, config: &Config) -> Result
                 let description = pi.description.as_deref().unwrap_or(&p.name);
                 let p_ty = ident(name, &config.ident_formats.peripheral, span);
                 let name_str = p_ty.to_string();
-                let address = util::hex(pi.base_address);
+                let address = util::hex(pi.base_address + config.base_address_shift);
                 let p_snake = name.to_sanitized_snake_case();
                 snake_names.push(p_snake.to_string());
                 let mut feature_attribute_n = feature_attribute.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -200,6 +200,17 @@ fn run() -> Result<()> {
                 .help("Reexport interrupt macro from cortex-m-rt like crates"),
         )
         .arg(
+            Arg::new("base_address_shift")
+                .short('b')
+                .long("base-address-shift")
+                .alias("base_address_shift")
+                .action(ArgAction::Set)
+                .help("Add offset to all base addresses on all peripherals in the SVD file.")
+                .long_help("Add offset to all base addresses on all peripherals in the SVD file.
+Useful for soft-cores where the peripheral address range isn't necessarily fixed.
+Ignore this option if you are not building your own FPGA based soft-cores."),
+        )
+        .arg(
             Arg::new("log_level")
                 .long("log")
                 .short('l')


### PR DESCRIPTION
Hello!
We are working with the FPGA-based project and unlike with micro-controllers all peripherals are dynamic.
In order to swap different devices (described within several SVD files) in a single board we need to be able to move their addresses.
That's why in this PR we added a flag to shift all base addresses provided in SVD.