### PR TITLE
Custom prefix/case/suffix for identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Custom prefix/case/suffix for identifiers
+
 ## [v0.31.3] - 2023-12-25
 
 - Add `svd::Device` validation after parsing by `serde`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -941,14 +941,14 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.10.2"
+version = "1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "380b951a9c5e80ddfd6136919eef32310721aa4aacd4889a8d39124b026ab343"
+checksum = "ebee201405406dbf528b8b672104ae6d6d63e6d118cb10e4d51abbc7b58044ff"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.3",
- "regex-syntax 0.8.2",
+ "regex-automata 0.3.9",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -962,13 +962,13 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.3"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f804c7828047e88b2d32e2d7fe5a105da8ee3264f01902f796c8e067dc2483f"
+checksum = "59b23e92ee4318893fa3fe3e6fb365258efbfe6ac6ab30f090cdcbb7aa37efa9"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.2",
+ "regex-syntax 0.7.5",
 ]
 
 [[package]]
@@ -979,9 +979,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.2"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "reqwest"
@@ -1023,12 +1023,9 @@ dependencies = [
 
 [[package]]
 name = "roxmltree"
-version = "0.18.1"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "862340e351ce1b271a378ec53f304a5558f7db87f3769dc655a8f6ecbb68b302"
-dependencies = [
- "xmlparser",
-]
+checksum = "3cd14fd5e3b777a7422cca79358c57a8f6e3a703d9ac187448d0daf220c2407f"
 
 [[package]]
 name = "rustc-demangle"
@@ -1194,9 +1191,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "svd-parser"
-version = "0.14.4"
+version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b49637951d99ea9f89b2bfb269ff0a21b8d647d01b0bb9949987b98871548fef"
+checksum = "3d17a2c2ef5aa450e80d714232a5932e7d8a39cac092e9e9ef8411bc833de3c4"
 dependencies = [
  "anyhow",
  "roxmltree",
@@ -1206,9 +1203,9 @@ dependencies = [
 
 [[package]]
 name = "svd-rs"
-version = "0.14.6"
+version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88d664449a290ecd6253d977d350cdf4026781223a72473fc55ea1e456e2b5d9"
+checksum = "1c82f375efa1d0145467e6cc98fa0e4e1a3f3d497cece4bcdda247f4904a77d4"
 dependencies = [
  "once_cell",
  "regex",
@@ -1870,9 +1867,3 @@ dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
 ]
-
-[[package]]
-name = "xmlparser"
-version = "0.13.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,11 +60,11 @@ html-escape = "0.2"
 
 [dependencies.svd-parser]
 features = ["expand"]
-version = "0.14.4"
+version = "0.14.5"
 
 [dependencies.svd-rs]
 features = ["serde"]
-version = "0.14.6"
+version = "0.14.7"
 
 [dependencies.syn]
 version = "2.0"

--- a/src/config.rs
+++ b/src/config.rs
@@ -163,26 +163,6 @@ impl IdentFormat {
         self.suffix = suffix.into();
         self
     }
-    pub fn parse(s: &str) -> Result<Self, ()> {
-        let mut it = s.split(":");
-        match (it.next(), it.next(), it.next(), it.next()) {
-            (Some(prefix), Some(case), Some(suffix), None) => {
-                let case = match case {
-                    "C" | "CONSTANT" => Some(Case::Constant),
-                    "P" | "Pascal" => Some(Case::Pascal),
-                    "S" | "snake" => Some(Case::Snake),
-                    "_" => None,
-                    _ => return Err(()),
-                };
-                Ok(Self {
-                    case,
-                    prefix: prefix.into(),
-                    suffix: suffix.into(),
-                })
-            }
-            _ => Err(()),
-        }
-    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,7 @@ impl SourceType {
     serde(rename_all = "lowercase")
 )]
 #[derive(Clone, Debug, PartialEq, Eq, Default)]
+#[non_exhaustive]
 pub enum Case {
     #[default]
     Constant,

--- a/src/main.rs
+++ b/src/main.rs
@@ -171,12 +171,13 @@ fn run() -> Result<()> {
                 .action(ArgAction::SetTrue)
                 .help("Make advanced checks due to parsing SVD"),
         )
+        // TODO: deprecate
         .arg(
             Arg::new("pascal_enum_values")
                 .long("pascal-enum-values")
                 .alias("pascal_enum_values")
                 .action(ArgAction::SetTrue)
-                .help("Use PascalCase in stead of UPPER_CASE for enumerated values"),
+                .help("Use PascalCase in stead of CONSTANT_CASE for enumerated values"),
         )
         .arg(
             Arg::new("source_type")
@@ -248,6 +249,9 @@ fn run() -> Result<()> {
         config.source_type = SourceType::from_path(file)
     }
     let path = config.output_dir.as_deref().unwrap_or(Path::new("."));
+    if config.pascal_enum_values {
+        config.ident_formats.enum_value.case = Some(svd2rust::config::Case::Pascal);
+    }
 
     info!("Parsing device from SVD file");
     let device = load_from(input, &config)?;


### PR DESCRIPTION
This PR doesn't add new cli options (yet?). But you can pass options by config:
```
❯ cat svd2rust.toml 
make_mod = true
generic_mod = true
strict = true
pascal_enum_values = true
max_cluster_size = true
atomics = true
atomics_feature = "atomics"
debug_impl = true
defmt_impl = "defmt"
reexport_core_peripherals = true
reexport_interrupt = true

[ident_formats.register_spec]
case = "constant"
suffix = "rs"

[ident_formats.enum_name]
case = "constant"

[ident_formats.enum_write_name]
case = "constant"
prefix = "w"

[ident_formats.field_reader]
case = "constant"
suffix = "r"

[ident_formats.field_writer]
case = "constant"
suffix = "w"
```
cc @Emilgardis what do you think?
This should not be a breaking change.