### PR TITLE
fix missing move in register/cluster array iter closure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-- Fix `cargo doc` constants generation 
+- `move` in `RegisterBlock::reg_iter` implementation (iterator of register/cluster array)
+- Fix `cargo doc` constants generation
 
 ## [v0.31.4] - 2024-01-03
 

--- a/src/generate/peripheral/accessor.rs
+++ b/src/generate/peripheral/accessor.rs
@@ -190,7 +190,7 @@ impl ToTokens for RawArrayAccessor {
             #[doc = #doc]
             #[inline(always)]
             pub fn #name_iter(&self) -> impl Iterator<Item=&#ty> {
-                (0..#dim).map(|n| #cast)
+                (0..#dim).map(move |n| #cast)
             }
         }
         .to_tokens(tokens);


### PR DESCRIPTION
fixes #798

same fix as done in #789 which was caused by #775