### PR TITLE
Generating type alias of derived enumeratedValues.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Fixed re-export of derived enumeration values
+
 ## [v0.32.0] - 2024-02-26
 
 - Bump MSRV to 1.74

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -691,8 +691,13 @@ pub fn fields(
             if let Some(dpath) = dpath {
                 epath = Some(derive_enumerated_values(&mut ev, &dpath, &fpath, index)?);
                 // TODO: remove this hack
-                if let Some(epath) = epath.as_ref() {
-                    ev = (*index.evs.get(epath).unwrap()).clone();
+                //if let Some(epath) = epath.as_ref() {
+                //    ev = (*index.evs.get(epath).unwrap()).clone();
+                //}
+                // The field name is used in the enumerated_value name,
+                // if the enumerated_value does not have a name.
+                if ev.name == None {
+                    ev.name = Some(f.name.clone());
                 }
             } else if let Some(path) = fdpath.as_ref() {
                 epath = Some(


### PR DESCRIPTION
svd file
```XML
            <field>
              <name>SAI1SEL</name>
              <description>SAI1 and DFSDM1 kernel Aclk clock source
              selection</description>
              <bitOffset>0</bitOffset>
              <bitWidth>3</bitWidth>
              <enumeratedValues>
                <name>SAI1SEL</name>
                <enumeratedValue>
                  <name>PLL1_Q</name>
                  <description>pll1_q selected as peripheral clock</description>
                  <value>0</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>PLL2_P</name>
                  <description>pll2_p selected as peripheral clock</description>
                  <value>1</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>PLL3_P</name>
                  <description>pll3_p selected as peripheral clock</description>
                  <value>2</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>I2S_CKIN</name>
                  <description>I2S_CKIN selected as peripheral clock</description>
                  <value>3</value>
                </enumeratedValue>
                <enumeratedValue>
                  <name>PER</name>
                  <description>PER selected as peripheral clock</description>
                  <value>4</value>
                </enumeratedValue>
              </enumeratedValues>
            </field>
            <field>
              <name>SAI23SEL</name>
              <description>SAI2 and SAI3 kernel clock source
              selection</description>
              <bitOffset>6</bitOffset>
              <bitWidth>3</bitWidth>
              <enumeratedValues derivedFrom="SAI1SEL"/>
            </field>
            <field>
              <name>SPI123SEL</name>
              <description>SPI/I2S1,2 and 3 kernel clock source
              selection</description>
              <bitOffset>12</bitOffset>
              <bitWidth>3</bitWidth>
              <enumeratedValues derivedFrom="SAI1SEL"/>
            </field>
```

generated rust code from the above svd file. 
```Rust
pub enum SAI1SEL {
    #[doc = "0: pll1_q selected as peripheral clock"]
    Pll1Q = 0,
    #[doc = "1: pll2_p selected as peripheral clock"]
    Pll2P = 1,
    #[doc = "2: pll3_p selected as peripheral clock"]
    Pll3P = 2,
    #[doc = "3: I2S_CKIN selected as peripheral clock"]
    I2sCkin = 3,
    #[doc = "4: PER selected as peripheral clock"]
    Per = 4,
}

impl SAI1SEL_R {
}

pub type SAI1SEL_W<'a, REG> = crate::FieldWriter<'a, REG, 3, SAI1SEL>;
impl<'a, REG> SAI1SEL_W<'a, REG>
where
    REG: crate::Writable + crate::RegisterSpec,
    REG::Ux: From<u8>,
{
}

#[doc = "Field `SAI23SEL` reader - SAI2 and SAI3 kernel clock source selection"]
pub use SAI1SEL_R as SAI23SEL_R;
#[doc = "Field `SPI123SEL` reader - SPI/I2S1,2 and 3 kernel clock source selection"]
pub use SAI1SEL_R as SPI123SEL_R;
#[doc = "Field `SAI23SEL` writer - SAI2 and SAI3 kernel clock source selection"]
pub use SAI1SEL_W as SAI23SEL_W;
#[doc = "Field `SPI123SEL` writer - SPI/I2S1,2 and 3 kernel clock source selection"]
pub use SAI1SEL_W as SPI123SEL_W;

```

`svd2rust` does not generate type aliase of SAI23SEL and SPI123SEL.
I would like to append type aliase of SAI23SEL and SPI123SEL.

```Rust
pub type SAI23SEL = SAI1SEL;
pub type SPI123SEL = SAI1SEL;
```

Because, if the enumerator names do not match the names of Field Reader and Filed Writer, you will be in trouble when you generate the code with macros.
And if the enumerator names do not match the names of Field Reader and Filed Writer, the code is difficult to write and may cause bugs.