### PR TITLE
Debug impl cleanups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Remove unneeded `format_args` in register `Debug` impl
+
 ## [v0.33.1] - 2024-04-20
 
 - Add checked `set` for not full safe fields

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -476,7 +476,7 @@ fn render_register_mod_debug(
                         let f_name_n = field_accessor(&f.name.expand_dim(&suffix), config, span);
                         let f_name_n_s = format!("{f_name_n}");
                         r_debug_impl.extend(quote! {
-                            .field(#f_name_n_s, &format_args!("{}", self.#f_name_n().#bit_or_bits()))
+                            .field(#f_name_n_s, &self.#f_name_n().#bit_or_bits())
                         });
                     }
                 } else {
@@ -484,7 +484,7 @@ fn render_register_mod_debug(
                     let f_name = field_accessor(&f_name, config, span);
                     let f_name_s = format!("{f_name}");
                     r_debug_impl.extend(quote! {
-                        .field(#f_name_s, &format_args!("{}", self.#f_name().#bit_or_bits()))
+                        .field(#f_name_s, &self.#f_name().#bit_or_bits())
                     });
                 }
             }


### PR DESCRIPTION
[DebugStruct::field](https://doc.rust-lang.org/std/fmt/struct.DebugStruct.html#method.field) takes `&dyn Debug`. For primitive types it should give same result as `Display`.