### PR TITLE
use ConstZero instead of Default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: master
+    branches: [master]
   pull_request:
   merge_group:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Generic `Periph<RB, A>`
+- use `ConstZero::ZERO` instead of `Default::default()` to force const
 - Add `mtvec_align` field to `riscv_config` to configure the byte alignment of interrupt vector table.
 - Fix reexport path when "%s" inside "derivedFrom"
 - Force using rust edition 2021 in CI

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -49,7 +49,6 @@ impl<RB, const A: usize> core::ops::Deref for Periph<RB, A> {
 /// Raw register type (`u8`, `u16`, `u32`, ...)
 pub trait RawReg:
     Copy
-    + Default
     + From<bool>
     + core::ops::BitOr<Output = Self>
     + core::ops::BitAnd<Output = Self>
@@ -60,8 +59,10 @@ pub trait RawReg:
 {
     /// Mask for bits of width `WI`
     fn mask<const WI: u8>() -> Self;
-    /// Mask for bits of width 1
-    fn one() -> Self;
+    /// `0`
+    const ZERO: Self;
+    /// `1`
+    const ONE: Self;
 }
 
 macro_rules! raw_reg {
@@ -71,10 +72,8 @@ macro_rules! raw_reg {
             fn mask<const WI: u8>() -> Self {
                 $mask::<WI>()
             }
-            #[inline(always)]
-            fn one() -> Self {
-                1
-            }
+            const ZERO: Self = 0;
+            const ONE: Self = 1;
         }
         const fn $mask<const WI: u8>() -> $U {
             <$U>::MAX >> ($size - WI)
@@ -120,10 +119,10 @@ pub trait Writable: RegisterSpec {
     type Safety;
 
     /// Specifies the register bits that are not changed if you pass `1` and are changed if you pass `0`
-    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux;
+    const ZERO_TO_MODIFY_FIELDS_BITMAP: Self::Ux = Self::Ux::ZERO;
 
     /// Specifies the register bits that are not changed if you pass `0` and are changed if you pass `1`
-    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux;
+    const ONE_TO_MODIFY_FIELDS_BITMAP: Self::Ux = Self::Ux::ZERO;
 }
 
 /// Reset value of the register.
@@ -132,7 +131,7 @@ pub trait Writable: RegisterSpec {
 /// register by using the `reset` method.
 pub trait Resettable: RegisterSpec {
     /// Reset value of the register.
-    const RESET_VALUE: Self::Ux;
+    const RESET_VALUE: Self::Ux = Self::Ux::ZERO;
 
     /// Reset value of the register.
     #[inline(always)]
@@ -539,8 +538,8 @@ macro_rules! bit_proxy {
             /// Writes bit to the field
             #[inline(always)]
             pub fn bit(self, value: bool) -> &'a mut W<REG> {
-                self.w.bits &= !(REG::Ux::one() << self.o);
-                self.w.bits |= (REG::Ux::from(value) & REG::Ux::one()) << self.o;
+                self.w.bits &= !(REG::Ux::ONE << self.o);
+                self.w.bits |= (REG::Ux::from(value) & REG::Ux::ONE) << self.o;
                 self.w
             }
             /// Writes `variant` to the field
@@ -568,13 +567,13 @@ where
     /// Sets the field bit
     #[inline(always)]
     pub fn set_bit(self) -> &'a mut W<REG> {
-        self.w.bits |= REG::Ux::one() << self.o;
+        self.w.bits |= REG::Ux::ONE << self.o;
         self.w
     }
     /// Clears the field bit
     #[inline(always)]
     pub fn clear_bit(self) -> &'a mut W<REG> {
-        self.w.bits &= !(REG::Ux::one() << self.o);
+        self.w.bits &= !(REG::Ux::ONE << self.o);
         self.w
     }
 }
@@ -587,7 +586,7 @@ where
     /// Sets the field bit
     #[inline(always)]
     pub fn set_bit(self) -> &'a mut W<REG> {
-        self.w.bits |= REG::Ux::one() << self.o;
+        self.w.bits |= REG::Ux::ONE << self.o;
         self.w
     }
 }
@@ -600,7 +599,7 @@ where
     /// Clears the field bit
     #[inline(always)]
     pub fn clear_bit(self) -> &'a mut W<REG> {
-        self.w.bits &= !(REG::Ux::one() << self.o);
+        self.w.bits &= !(REG::Ux::ONE << self.o);
         self.w
     }
 }
@@ -613,7 +612,7 @@ where
     ///Clears the field bit by passing one
     #[inline(always)]
     pub fn clear_bit_by_one(self) -> &'a mut W<REG> {
-        self.w.bits |= REG::Ux::one() << self.o;
+        self.w.bits |= REG::Ux::ONE << self.o;
         self.w
     }
 }
@@ -626,7 +625,7 @@ where
     ///Sets the field bit by passing zero
     #[inline(always)]
     pub fn set_bit_by_zero(self) -> &'a mut W<REG> {
-        self.w.bits &= !(REG::Ux::one() << self.o);
+        self.w.bits &= !(REG::Ux::ONE << self.o);
         self.w
     }
 }
@@ -639,7 +638,7 @@ where
     ///Toggle the field bit by passing one
     #[inline(always)]
     pub fn toggle_bit(self) -> &'a mut W<REG> {
-        self.w.bits |= REG::Ux::one() << self.o;
+        self.w.bits |= REG::Ux::ONE << self.o;
         self.w
     }
 }
@@ -652,7 +651,7 @@ where
     ///Toggle the field bit by passing zero
     #[inline(always)]
     pub fn toggle_bit(self) -> &'a mut W<REG> {
-        self.w.bits &= !(REG::Ux::one() << self.o);
+        self.w.bits &= !(REG::Ux::ONE << self.o);
         self.w
     }
 }

--- a/src/generate/generic_atomic.rs
+++ b/src/generate/generic_atomic.rs
@@ -39,7 +39,7 @@ mod atomic {
 
     impl<REG: Readable + Writable> Reg<REG>
     where
-        REG::Ux: AtomicOperations
+        REG::Ux: AtomicOperations,
     {
         /// Set high every bit in the register that was set in the write proxy. Leave other bits
         /// untouched. The write is done in a single atomic instruction.
@@ -53,7 +53,7 @@ mod atomic {
             F: FnOnce(&mut W<REG>) -> &mut W<REG>,
         {
             let bits = f(&mut W {
-                bits: Default::default(),
+                bits: REG::Ux::ZERO,
                 _reg: marker::PhantomData,
             })
             .bits;
@@ -72,7 +72,7 @@ mod atomic {
             F: FnOnce(&mut W<REG>) -> &mut W<REG>,
         {
             let bits = f(&mut W {
-                bits: !REG::Ux::default(),
+                bits: !REG::Ux::ZERO,
                 _reg: marker::PhantomData,
             })
             .bits;
@@ -91,7 +91,7 @@ mod atomic {
             F: FnOnce(&mut W<REG>) -> &mut W<REG>,
         {
             let bits = f(&mut W {
-                bits: Default::default(),
+                bits: REG::Ux::ZERO,
                 _reg: marker::PhantomData,
             })
             .bits;

--- a/src/generate/generic_reg_vcell.rs
+++ b/src/generate/generic_reg_vcell.rs
@@ -148,7 +148,7 @@ impl<REG: Writable> Reg<REG> {
         F: FnOnce(&mut W<REG>) -> &mut W<REG>,
     {
         let value = f(&mut W {
-            bits: REG::Ux::default(),
+            bits: REG::Ux::ZERO,
             _reg: marker::PhantomData,
         })
         .bits;
@@ -169,7 +169,7 @@ impl<REG: Writable> Reg<REG> {
         F: FnOnce(&mut W<REG>) -> T,
     {
         let mut writer = W {
-            bits: REG::Ux::default(),
+            bits: REG::Ux::ZERO,
             _reg: marker::PhantomData,
         };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -255,6 +255,11 @@ pub fn hex(n: u64) -> LitInt {
     )
 }
 
+/// Turns non-zero `n` into an unsuffixed separated hex token
+pub fn hex_nonzero(n: u64) -> Option<LitInt> {
+    (n != 0).then(|| hex(n))
+}
+
 /// Turns `n` into an unsuffixed token
 pub fn unsuffixed(n: impl Into<u64>) -> LitInt {
     LitInt::new(&n.into().to_string(), Span::call_site())


### PR DESCRIPTION
Advantages:
- more `const`s
- `zero` is more semantically correct then `default`
- cleaner code

Disadvantages:
- `rustdoc` still not good with `const defaults`. Prints 
![изображение](https://github.com/user-attachments/assets/4c1732ee-4d81-48b7-8eb5-43d1de750dad)

instead of `const ZERO_TO_MODIFY_FIELDS_BITMAP: u32 = 0` for default value.

cc @Emilgardis 