### PR TITLE
Generate unique id for device peripherals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Fix `enumeratedValues` with `isDefault` only
-- Remove `#[no_mangle]` attribute of `DEVICE_PERIPHERALS` to solve
+- Generate unique identifier instead of `DEVICE_PERIPHERALS` to solve
   the link time issue when multiple devices used
 
 ## [v0.33.4] - 2024-06-16


### PR DESCRIPTION
Hi! I encoutered errors when compiling project with multiple devices used and lto enabled.
The problem is similar to this [issue](https://github.com/rust-lang/rust/issues/98666) with generated variable `DEVICE_PERIPHERALS`.
This PR solves the problem by generating unique name based on the device name ~~removing `#[no_mangle]` attribute~~.