### PR TITLE
Restrict `proc-macro2` to Version 1.0.86

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -893,9 +893,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.71"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75cb1540fadbd5b8fbccc4dddad2734eba435053f725621c070711a14bb5f4b8"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,7 @@ env_logger = { version = "0.11", optional = true }
 inflections = "1.1"
 log = { version = "~0.4", features = ["std"] }
 quote = "1.0"
-proc-macro2 = "1.0"
+proc-macro2 = "=1.0.86"
 anyhow = "1.0"
 thiserror = "1.0"
 serde = { version = "1.0", optional = true }


### PR DESCRIPTION
I noticed that `proc-macro2` version `1.0.87` introduced character validation for the `Punct` struct, resulting in `svd2rust` panicking like so:

```
thread 'main' panicked at {me}/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.87/src/lib.rs:847:13:
unsupported proc macro punctuation character '{'
```

Temporary solution is holding back `proc-macro2` at version `1.0.86`. Better solution would probably be representing the `{` character with a different struct than `Punct`.