### PR TITLE
return raw value from write/modify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Skip generating `.add(0)` and `1 *` in accessors
 - Bump MSRV of generated code to 1.76
 - move `must_use` from methods to generic type
-- Add `write_and`, `write_with_zero_and`, and `modify_and` register modifiers
+- *breaking change* Return raw writtened value
+- Add `from_write`, `from_write_with_zero`, and `from_modify` register modifiers
+  with generic return value
 
 ## [v0.33.5] - 2024-10-12
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -589,7 +589,7 @@ main() {
             test_patched_stm32 stm32f7x3
             test_patched_stm32 stm32g070
             test_patched_stm32 stm32g473
-            test_patched_stm32 stm32h753
+            test_patched_stm32 stm32h743
             test_patched_stm32 stm32l0x3
             test_patched_stm32 stm32l162
             test_patched_stm32 stm32l4x6

--- a/src/generate/generic_reg_vcell.rs
+++ b/src/generate/generic_reg_vcell.rs
@@ -74,18 +74,18 @@ impl<REG: Resettable + Writable> Reg<REG> {
     /// ```
     /// In the latter case, other fields will be set to their reset value.
     #[inline(always)]
-    pub fn write<F>(&self, f: F)
+    pub fn write<F>(&self, f: F) -> REG::Ux
     where
         F: FnOnce(&mut W<REG>) -> &mut W<REG>,
     {
-        self.register.set(
-            f(&mut W {
-                bits: REG::RESET_VALUE & !REG::ONE_TO_MODIFY_FIELDS_BITMAP
-                    | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
-                _reg: marker::PhantomData,
-            })
-            .bits,
-        );
+        let value = f(&mut W {
+            bits: REG::RESET_VALUE & !REG::ONE_TO_MODIFY_FIELDS_BITMAP
+                | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
+            _reg: marker::PhantomData,
+        })
+        .bits;
+        self.register.set(value);
+        value
     }
 
     /// Writes bits to a `Writable` register and produce a value.
@@ -143,17 +143,17 @@ impl<REG: Writable> Reg<REG> {
     ///
     /// Unsafe to use with registers which don't allow to write 0.
     #[inline(always)]
-    pub unsafe fn write_with_zero<F>(&self, f: F)
+    pub unsafe fn write_with_zero<F>(&self, f: F) -> REG::Ux
     where
         F: FnOnce(&mut W<REG>) -> &mut W<REG>,
     {
-        self.register.set(
-            f(&mut W {
-                bits: REG::Ux::default(),
-                _reg: marker::PhantomData,
-            })
-            .bits,
-        );
+        let value = f(&mut W {
+            bits: REG::Ux::default(),
+            _reg: marker::PhantomData,
+        })
+        .bits;
+        self.register.set(value);
+        value
     }
 
     /// Writes 0 to a `Writable` register and produces a value.
@@ -208,25 +208,24 @@ impl<REG: Readable + Writable> Reg<REG> {
     /// ```
     /// Other fields will have the value they had before the call to `modify`.
     #[inline(always)]
-    pub fn modify<F>(&self, f: F)
+    pub fn modify<F>(&self, f: F) -> REG::Ux
     where
         for<'w> F: FnOnce(&R<REG>, &'w mut W<REG>) -> &'w mut W<REG>,
     {
         let bits = self.register.get();
-        self.register.set(
-            f(
-                &R {
-                    bits,
-                    _reg: marker::PhantomData,
-                },
-                &mut W {
-                    bits: bits & !REG::ONE_TO_MODIFY_FIELDS_BITMAP
-                        | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
-                    _reg: marker::PhantomData,
-                },
-            )
-            .bits,
-        );
+        let value = f(
+            &R {
+                bits,
+                _reg: marker::PhantomData,
+            },
+            &mut W {
+                bits: bits & !REG::ONE_TO_MODIFY_FIELDS_BITMAP | REG::ZERO_TO_MODIFY_FIELDS_BITMAP,
+                _reg: marker::PhantomData,
+            },
+        )
+        .bits;
+        self.register.set(value);
+        value
     }
 
     /// Modifies the contents of the register by reading and then writing it


### PR DESCRIPTION
This looks not so beautiful like #738, but almost not breaking and allows to transfer data between writes with unsafe.
```rust
    let bits = rcc.apb1rstr().modify(|_, w| w.usart2rst().clear_bit());
    rcc.apb1rstr().write(|w| unsafe { // save on 1 read operation
        w.bits(bits).usart2rst().set_bit()
    });
```