### PR TITLE
Do not implement InterruptNumber for XtensaLx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - *breaking change* Return raw writtened value
 - Add `from_write`, `from_write_with_zero`, and `from_modify` register modifiers
   with generic return value
+- `InterruptNumber` is no longer implemented for Xtensa peripheral interrupts
 
 ## [v0.33.5] - 2024-10-12
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -308,13 +308,6 @@ pub fn render(
                 root.extend(quote! {
                     #interrupt_enum
 
-                    unsafe impl xtensa_lx::interrupt::InterruptNumber for Interrupt {
-                        #[inline(always)]
-                        fn number(#self_token) -> u16 {
-                            #nr_expr
-                        }
-                    }
-
                     /// TryFromInterruptError
                     #defmt
                     #[derive(Debug, Copy, Clone)]


### PR DESCRIPTION
InterruptNumber is not useful for us because it's meant to provide an interface for CPU interrupts, but it's implemented by svd2rust for peripheral interrupts.