### PR TITLE
Do not emit inner attributes for MSP430 with make_mod option active.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Fix MSP430 PAC inner attribute generation when used with the `-m` switch.
+
 ## [v0.34.0] - 2024-11-05
 
 - Revert #711

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -41,7 +41,8 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         None => None,
     };
 
-    if config.target == Target::Msp430 {
+    // make_mod option explicitly disables inner attributes.
+    if config.target == Target::Msp430 && !config.make_mod {
         out.extend(quote! {
             #![feature(abi_msp430_interrupt)]
         });


### PR DESCRIPTION
I have been trying an experiment to generate MSP430 PACs automatically like e.g. [stm-rs does](https://github.com/stm32-rs/stm32-rs).

I am blocked on this patch being accepted, which is technically a bug fix.