### PR TITLE
lifetime ellision for FieldWriter to fix clippy warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Force using rust edition 2021 in CI
+- Added lifetime ellision for `FieldWriter` where the explicit lifetimes are not necessary, which
+  fixes the `clippy::needless_lifetimes` warning on rustc 1.84
 
 ## [v0.35.0] - 2024-11-12
 

--- a/ci/script.sh
+++ b/ci/script.sh
@@ -586,7 +586,7 @@ main() {
             test_patched_stm32 stm32f103
             test_patched_stm32 stm32f411
             test_patched_stm32 stm32f469
-            test_patched_stm32 stm32f7x3
+            test_patched_stm32 stm32f723
             test_patched_stm32 stm32g070
             test_patched_stm32 stm32g473
             test_patched_stm32 stm32h743

--- a/ci/svd2rust-regress/tests.yml
+++ b/ci/svd2rust-regress/tests.yml
@@ -1863,8 +1863,8 @@
   svd_url: https://stm32-rs.github.io/stm32-rs/stm32f469.svd.patched
 - arch: cortex-m
   mfgr: STMicro
-  chip: STM32F7x3
-  svd_url: https://stm32-rs.github.io/stm32-rs/stm32f7x3.svd.patched
+  chip: STM32F723
+  svd_url: https://stm32-rs.github.io/stm32-rs/stm32f723.svd.patched
 - arch: cortex-m
   mfgr: STMicro
   chip: STM32G070

--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -337,7 +337,7 @@ pub struct RangeTo<const MAX: u64>;
 /// Write field Proxy
 pub type FieldWriter<'a, REG, const WI: u8, FI = u8, Safety = Unsafe> = raw::FieldWriter<'a, REG, WI, FI, Safety>;
 
-impl<'a, REG, const WI: u8, FI, Safety> FieldWriter<'a, REG, WI, FI, Safety>
+impl<REG, const WI: u8, FI, Safety> FieldWriter<'_, REG, WI, FI, Safety>
 where
     REG: Writable + RegisterSpec,
     FI: FieldSpec,


### PR DESCRIPTION
I tested this with v1.76 using the svd2rust-regress tool. Fixes #895 