### PR TITLE
improve docs of generated library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Other internal clippy fixes for `clippy::manual_div_ceil`, `clippy::nonminimal_bool` and
   `clippy::needless_lifetimes`
 - Update `svd-rs` to 0.14.11
+- Added `#![cfg_attr(docsrs, feature(doc_auto_cfg))]` to the generated library code. This
+  adds a display of the feature gates in the documentation of the generated library
 
 ## [v0.35.0] - 2024-11-12
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -59,6 +59,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]
             #![no_std]
+            #![cfg_attr(docsrs, feature(doc_auto_cfg))]
         });
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,23 @@
 //! v-trap = ["rt", "riscv-rt/v-trap"]
 //! ```
 //!
+//! ## Generating documentation
+//!
+//! You can generate the documentation for the generated library using the following command:
+//!
+//! ```sh
+//! RUSTDOCFLAGS="--cfg docsrs --generate-link-to-definition -Z unstable-options" cargo +nightly doc --all-features --open
+//! ```
+//!
+//! It is recommended to add the following block in the `Cargo.toml` of the generated library
+//! if you plan to host the library documentaion on `docs.rs`
+//!
+//! ```toml
+//! [package.metadata.docs.rs]
+//! all-features = true
+//! rustdoc-args = ["--generate-link-to-definition"]
+//! ```
+//!
 //! # Peripheral API
 //!
 //! To use a peripheral first you must get an *instance* of the peripheral. All the device


### PR DESCRIPTION
This adds feature gate displays, for example like the ones in the [syn docs](https://docs.rs/syn/latest/syn/).
The generated library only has a few of those, but I find them to be very useful. Fixes https://github.com/rust-embedded/svd2rust/issues/855