### PR TITLE
[#experiment ]Associated Reader/Writer

### DIFF
--- a/src/generate/generic.rs
+++ b/src/generate/generic.rs
@@ -104,10 +104,23 @@ pub trait FieldSpec: Sized {
 /// Marker for fields with fixed values
 pub trait IsEnum: FieldSpec {}
 
+#[doc(hidden)]
+pub trait FromBits<U> {
+    unsafe fn from_bits(b: U) -> Self;
+}
+
+#[doc(hidden)]
+pub trait ToBits<U> {
+    fn to_bits(&self) -> U;
+}
+
 /// Trait implemented by readable registers to enable the `read` method.
 ///
 /// Registers marked with `Writable` can be also be `modify`'ed.
-pub trait Readable: RegisterSpec {}
+pub trait Readable: RegisterSpec {
+    /// Reader struct associated with register
+    type Reader: FromBits<Self::Ux>;
+}
 
 /// Trait implemented by writeable registers.
 ///
@@ -115,6 +128,9 @@ pub trait Readable: RegisterSpec {}
 ///
 /// Registers marked with `Readable` can be also be `modify`'ed.
 pub trait Writable: RegisterSpec {
+    /// Writer struct associated with register
+    type Writer: FromBits<Self::Ux> + ToBits<Self::Ux>;
+
     /// Is it safe to write any bits to register
     type Safety;
 
@@ -140,19 +156,54 @@ pub trait Resettable: RegisterSpec {
     }
 }
 
+/// Marker for register/field writers which can take any value of specified width
+pub struct Safe;
+/// You should check that value is allowed to pass to register/field writer marked with this
+pub struct Unsafe;
+/// Marker for field writers are safe to write in specified inclusive range
+pub struct Range<const MIN: u64, const MAX: u64>;
+/// Marker for field writers are safe to write in specified inclusive range
+pub struct RangeFrom<const MIN: u64>;
+/// Marker for field writers are safe to write in specified inclusive range
+pub struct RangeTo<const MAX: u64>;
+
 #[doc(hidden)]
 pub mod raw {
-    use super::{marker, BitM, FieldSpec, RegisterSpec, Unsafe, Writable};
+    use super::{marker, BitM, FieldSpec, FromBits, RegisterSpec, ToBits, Unsafe, Writable};
 
     pub struct R<REG: RegisterSpec> {
         pub(crate) bits: REG::Ux,
         pub(super) _reg: marker::PhantomData<REG>,
     }
 
+    impl<REG: RegisterSpec> FromBits<REG::Ux> for R<REG> {
+        unsafe fn from_bits(bits: REG::Ux) -> Self {
+            Self {
+                bits,
+                _reg: marker::PhantomData,
+            }
+        }
+    }
+
     pub struct W<REG: RegisterSpec> {
         ///Writable bits
         pub(crate) bits: REG::Ux,
         pub(super) _reg: marker::PhantomData<REG>,
+    }
+
+    impl<REG: RegisterSpec> FromBits<REG::Ux> for W<REG> {
+        unsafe fn from_bits(bits: REG::Ux) -> Self {
+            Self {
+                bits,
+                _reg: marker::PhantomData,
+            }
+        }
+    }
+
+    impl<REG: RegisterSpec> ToBits<REG::Ux> for W<REG> {
+        fn to_bits(&self) -> REG::Ux {
+            self.bits
+        }
     }
 
     pub struct FieldReader<FI = u8>
@@ -370,17 +421,6 @@ impl<FI> core::fmt::Debug for BitReader<FI> {
         core::fmt::Debug::fmt(&self.bits, f)
     }
 }
-
-/// Marker for register/field writers which can take any value of specified width
-pub struct Safe;
-/// You should check that value is allowed to pass to register/field writer marked with this
-pub struct Unsafe;
-/// Marker for field writers are safe to write in specified inclusive range
-pub struct Range<const MIN: u64, const MAX: u64>;
-/// Marker for field writers are safe to write in specified inclusive range
-pub struct RangeFrom<const MIN: u64>;
-/// Marker for field writers are safe to write in specified inclusive range
-pub struct RangeTo<const MAX: u64>;
 
 /// Write field Proxy
 pub type FieldWriter<'a, REG, const WI: u8, FI = u8, Safety = Unsafe> =

--- a/src/generate/generic_atomic.rs
+++ b/src/generate/generic_atomic.rs
@@ -50,13 +50,9 @@ mod atomic {
         #[inline(always)]
         pub unsafe fn set_bits<F>(&self, f: F)
         where
-            F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+            F: FnOnce(&mut REG::Writer) -> &mut REG::Writer,
         {
-            let bits = f(&mut W {
-                bits: REG::Ux::ZERO,
-                _reg: marker::PhantomData,
-            })
-            .bits;
+            let bits = f(&mut REG::Writer::from_bits(REG::Ux::ZERO)).to_bits();
             REG::Ux::atomic_or(self.register.as_ptr(), bits);
         }
 
@@ -69,13 +65,9 @@ mod atomic {
         #[inline(always)]
         pub unsafe fn clear_bits<F>(&self, f: F)
         where
-            F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+            F: FnOnce(&mut REG::Writer) -> &mut REG::Writer,
         {
-            let bits = f(&mut W {
-                bits: !REG::Ux::ZERO,
-                _reg: marker::PhantomData,
-            })
-            .bits;
+            let bits = f(&mut REG::Writer::from_bits(!REG::Ux::ZERO)).to_bits();
             REG::Ux::atomic_and(self.register.as_ptr(), bits);
         }
 
@@ -88,13 +80,9 @@ mod atomic {
         #[inline(always)]
         pub unsafe fn toggle_bits<F>(&self, f: F)
         where
-            F: FnOnce(&mut W<REG>) -> &mut W<REG>,
+            F: FnOnce(&mut REG::Writer) -> &mut REG::Writer,
         {
-            let bits = f(&mut W {
-                bits: REG::Ux::ZERO,
-                _reg: marker::PhantomData,
-            })
-            .bits;
+            let bits = f(&mut REG::Writer::from_bits(REG::Ux::ZERO)).to_bits();
             REG::Ux::atomic_xor(self.register.as_ptr(), bits);
         }
     }

--- a/src/generate/register.rs
+++ b/src/generate/register.rs
@@ -386,7 +386,9 @@ pub fn render_register_mod(
         let doc = format!("`read()` method returns [`{mod_ty}::R`](R) reader structure",);
         mod_items.extend(quote! {
             #[doc = #doc]
-            impl crate::Readable for #regspec_ty {}
+            impl crate::Readable for #regspec_ty {
+                type Reader = R;
+            }
         });
     }
     if can_write {
@@ -421,6 +423,7 @@ pub fn render_register_mod(
         mod_items.extend(quote! {
             #[doc = #doc]
             impl crate::Writable for #regspec_ty {
+                type Writer = W;
                 type Safety = crate::#safe_ty;
                 #zero_to_modify_fields_bitmap
                 #one_to_modify_fields_bitmap


### PR DESCRIPTION
Related to #902

@rmsyn This is required step to make register write methods generic over crates: https://github.com/burrbull/reg

But it is slower to compile:
For example stm32f4 crate on old PC:
Before PR: 6.92 s
After PR: 10.23 s
