### PR TITLE
`riscv-peripheral` v0.3.0 rework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Adapt RISC-V specific codegen for `riscv-peripheral` v0.3.0 rework
+- Include `riscv-peripheral` peripherals in `Peripherals` struct
+
 ## [v0.36.1] - 2025-04-04
 
 - Update `irx-config`

--- a/src/config/riscv.rs
+++ b/src/config/riscv.rs
@@ -52,15 +52,16 @@ impl RiscvEnumItem {
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[non_exhaustive]
 pub struct RiscvClintConfig {
+    pub pub_new: bool,
     pub name: String,
-    pub freq: Option<usize>,
-    pub async_delay: bool,
+    pub mtime_freq: usize,
 }
 
 #[cfg_attr(feature = "serde", derive(serde::Deserialize), serde(default))]
 #[derive(Clone, PartialEq, Eq, Debug, Default)]
 #[non_exhaustive]
 pub struct RiscvPlicConfig {
+    pub pub_new: bool,
     pub name: String,
     pub core_interrupt: Option<String>,
     pub hart_id: Option<String>,


### PR DESCRIPTION
Related: https://github.com/rust-embedded/riscv/pull/288

The `riscv-peripheral` v0.3.0 rework aligns better with `svd2rust's scheme. I'm still polishing details. I will let you know once I have an updated version of `e310x`.