### PR TITLE
Make the interrupt table no_mangle on Xtensa

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Fix new `mismatched-lifetime-syntaxes` lint warnings
 - Adapt RISC-V specific codegen for `riscv-peripheral` v0.3.0 rework
 - Include `riscv-peripheral` peripherals in `Peripherals` struct
+- Ensure `__INTERRUPTS` are `#[no_mangle]` on Xtensa.
 
 ## [v0.36.1] - 2025-04-04
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -245,8 +245,9 @@ pub fn render(
                 }
 
                 #[cfg(feature = "rt")]
-                #link_section_attr
                 #[doc(hidden)]
+                #link_section_attr
+                #[no_mangle]
                 pub static __INTERRUPTS: [Vector; #n] = [
                     #elements
                 ];


### PR DESCRIPTION
This was an oversight discovered in https://github.com/esp-rs/esp-hal/issues/2589