### PR TITLE
Add unsafe block around `DEVICE_PERIPHERALS = true` in `Peripherals::steal()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Change `feature(doc_auto_cfg)` to `feature(doc_cfg)` to allow nightly docs to build.
 - Add unsafe block around `DEVICE_PERIPHERALS = true` in `Peripherals::steal()`
   to support Rust 2024 edition.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Add unsafe block around `DEVICE_PERIPHERALS = true` in `Peripherals::steal()`
+  to support Rust 2024 edition.
+
 ## [v0.37.0] - 2025-08-14
 
 - Fix new `mismatched-lifetime-syntaxes` lint warnings

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -59,7 +59,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             #![allow(non_camel_case_types)]
             #![allow(non_snake_case)]
             #![no_std]
-            #![cfg_attr(docsrs, feature(doc_auto_cfg))]
+            #![cfg_attr(docsrs, feature(doc_cfg))]
         });
     }
 

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -301,6 +301,12 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         quote!(#[no_mangle])
     };
 
+    let set_device_peripherals_true = if config.edition >= RustEdition::E2024 {
+        quote!(unsafe { DEVICE_PERIPHERALS = true })
+    } else {
+        quote!(DEVICE_PERIPHERALS = true;)
+    };
+
     out.extend(quote! {
         // NOTE `no_mangle` is used here to prevent linking different minor versions of the device
         // crate as that would let you `take` the device peripherals more than once (one per minor
@@ -339,7 +345,7 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
             /// Each of the returned peripherals must be used at most once.
             #[inline]
             pub unsafe fn steal() -> Self {
-                DEVICE_PERIPHERALS = true;
+                #set_device_peripherals_true
 
                 Peripherals {
                     #exprs


### PR DESCRIPTION
In edition 2024, `#[warn(unsafe_op_in_unsafe_fn)]` is [enabled by default](https://doc.rust-lang.org/edition-guide/rust-2024/unsafe-op-in-unsafe-fn.html).

This PR adds the unsafe block around mutating `DEVICE_PERIPHERALS` in the generated `Peripherals::steal()` function. I had considered only adding this if the `--edition=2024` flag was passed, but there is no harm in this being here even for earlier editions and is IMO clearer regardless. Though if folks disagree I can make that change.