### PR TITLE
Fix cluster info size calculation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Fix the cluster info size calculation.
+
 ## [v0.37.1] - 2025-10-17
 
 - Change `feature(doc_auto_cfg)` to `feature(doc_cfg)` to allow nightly docs to build.

--- a/src/generate/peripheral.rs
+++ b/src/generate/peripheral.rs
@@ -913,7 +913,7 @@ fn cluster_info_size_in_bits(info: &ClusterInfo, path: &BlockPath, config: &Conf
                     .map(|rbf| rbf.size)
                     .sum();
 
-                (reg.address_offset * BITS_PER_BYTE) + reg_size
+                reg_size
             }
             RegisterCluster::Cluster(clust) => {
                 (clust.address_offset * BITS_PER_BYTE) + cluster_size_in_bits(clust, path, config)?


### PR DESCRIPTION
This fixes generation of a pac for the LPC55S16 chip. Before, trying to generate this board's pac would result in the following error:

```
ERROR svd2rust] Error rendering device
    
    Caused by:
        0: can't render peripheral 'I2S0', group 'I2S'
        1: Could not expand register or cluster block
        2: can't expand cluster 'SECCHANNEL[%s]'
        3: Cluster SECCHANNEL[%s] has size 24928 bits that is more then array increment 256 bits
```