### PR TITLE
Add `--skip-peripherals-struct` flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 ## [Unreleased]
 
 - Use marker struct instead of address in `Periph` with `PeripheralSpec` trait
+- Add `--skip-peripherals-struct` flag to skip generating the `Peripherals`
+  struct, its `take`/`steal` impl and the `DEVICE_PERIPHERALS` static
 
 ## [v0.37.1] - 2025-10-17
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,7 @@ pub struct Config {
     pub generic_mod: bool,
     pub make_mod: bool,
     pub skip_crate_attributes: bool,
+    pub skip_peripherals_struct: bool,
     pub ignore_groups: bool,
     pub keep_list: bool,
     pub strict: bool,

--- a/src/generate/device.rs
+++ b/src/generate/device.rs
@@ -295,64 +295,66 @@ pub fn render(d: &Device, config: &Config, device_x: &mut String) -> Result<Toke
         }
     }
 
-    let nomangle = if config.edition >= RustEdition::E2024 {
-        quote!(#[unsafe(no_mangle)])
-    } else {
-        quote!(#[no_mangle])
-    };
+    if !config.skip_peripherals_struct {
+        let nomangle = if config.edition >= RustEdition::E2024 {
+            quote!(#[unsafe(no_mangle)])
+        } else {
+            quote!(#[no_mangle])
+        };
 
-    let set_device_peripherals_true = if config.edition >= RustEdition::E2024 {
-        quote!(unsafe { DEVICE_PERIPHERALS = true })
-    } else {
-        quote!(DEVICE_PERIPHERALS = true;)
-    };
+        let set_device_peripherals_true = if config.edition >= RustEdition::E2024 {
+            quote!(unsafe { DEVICE_PERIPHERALS = true })
+        } else {
+            quote!(DEVICE_PERIPHERALS = true;)
+        };
 
-    out.extend(quote! {
-        // NOTE `no_mangle` is used here to prevent linking different minor versions of the device
-        // crate as that would let you `take` the device peripherals more than once (one per minor
-        // version)
-        #nomangle
-        static mut DEVICE_PERIPHERALS: bool = false;
+        out.extend(quote! {
+            // NOTE `no_mangle` is used here to prevent linking different minor versions of the device
+            // crate as that would let you `take` the device peripherals more than once (one per minor
+            // version)
+            #nomangle
+            static mut DEVICE_PERIPHERALS: bool = false;
 
-        /// All the peripherals.
-        #[allow(non_snake_case)]
-        pub struct Peripherals {
-            #fields
-        }
-
-        impl Peripherals {
-            /// Returns all the peripherals *once*.
-            #[cfg(feature = "critical-section")]
-            #[inline]
-            pub fn take() -> Option<Self> {
-                critical_section::with(|_| {
-                    // SAFETY: We are in a critical section, so we have exclusive access
-                    // to `DEVICE_PERIPHERALS`.
-                    if unsafe { DEVICE_PERIPHERALS } {
-                        return None
-                    }
-
-                    // SAFETY: `DEVICE_PERIPHERALS` is set to `true` by `Peripherals::steal`,
-                    // ensuring the peripherals can only be returned once.
-                    Some(unsafe { Peripherals::steal() })
-                })
+            /// All the peripherals.
+            #[allow(non_snake_case)]
+            pub struct Peripherals {
+                #fields
             }
 
-            /// Unchecked version of `Peripherals::take`.
-            ///
-            /// # Safety
-            ///
-            /// Each of the returned peripherals must be used at most once.
-            #[inline]
-            pub unsafe fn steal() -> Self {
-                #set_device_peripherals_true
+            impl Peripherals {
+                /// Returns all the peripherals *once*.
+                #[cfg(feature = "critical-section")]
+                #[inline]
+                pub fn take() -> Option<Self> {
+                    critical_section::with(|_| {
+                        // SAFETY: We are in a critical section, so we have exclusive access
+                        // to `DEVICE_PERIPHERALS`.
+                        if unsafe { DEVICE_PERIPHERALS } {
+                            return None
+                        }
 
-                Peripherals {
-                    #exprs
+                        // SAFETY: `DEVICE_PERIPHERALS` is set to `true` by `Peripherals::steal`,
+                        // ensuring the peripherals can only be returned once.
+                        Some(unsafe { Peripherals::steal() })
+                    })
+                }
+
+                /// Unchecked version of `Peripherals::take`.
+                ///
+                /// # Safety
+                ///
+                /// Each of the returned peripherals must be used at most once.
+                #[inline]
+                pub unsafe fn steal() -> Self {
+                    #set_device_peripherals_true
+
+                    Peripherals {
+                        #exprs
+                    }
                 }
             }
-        }
-    });
+        });
+    }
 
     Ok(out)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,6 +246,13 @@ Allowed cases are `unchanged` (''), `pascal` ('p'), `constant` ('c') and `snake`
                 .help("Do not generate crate attributes"),
         )
         .arg(
+            Arg::new("skip_peripherals_struct")
+                .long("skip-peripherals-struct")
+                .alias("skip_peripherals_struct")
+                .action(ArgAction::SetTrue)
+                .help("Do not generate the `Peripherals` struct, its `take`/`steal` impl, and the `DEVICE_PERIPHERALS` static"),
+        )
+        .arg(
             Arg::new("strict")
                 .long("strict")
                 .short('s')


### PR DESCRIPTION
## Summary

Adds a new CLI flag `--skip-peripherals-struct` that skips generation of:

- the `Peripherals` struct (and its `#[allow(non_snake_case)]` fields),
- its `take`/`steal` impls,
- the `DEVICE_PERIPHERALS` static (and its `#[no_mangle]` attribute).

## Motivation

Some downstream PAC consumers manage their own `Peripherals` struct / singleton instead of using the one emitted by svd2rust. In that case the svd2rust-generated `DEVICE_PERIPHERALS` symbol is not just dead weight — because it's `#[no_mangle]`, it's a global symbol that can collide across crates and prevents Cargo from linking two minor versions of a PAC in the same binary (which is the whole reason the `#[no_mangle]` is there).

Concrete example: esp-pacs manages its own `Peripherals` in esp-hal and ran into exactly this problem. See [esp-rs/esp-pacs#427](https://github.com/esp-rs/esp-pacs/pull/427), which deletes ~1700 lines of hand-maintained overrides (custom `lib.rs` shims per chip) once svd2rust can be told not to emit the struct at all.

## AI Usage

Generative AI assisted the development of this PR, however I have carefully vetted and amended the code and believe it to be of decent quality. Review welcome.
