### PR TITLE
Ci/add wch riscv test

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -527,10 +527,15 @@ fn pascalcase() {
     assert_eq!(to_pascal_case("FOO_BAR_1_2_"), "FooBar1_2_");
 }
 
-fn test_escape_special_chars(){
+#[test]
+fn test_escape_special_chars() {
     assert_eq!(escape_special_chars("Array[0]"), "Array\\[0\\]");
     assert_eq!(escape_special_chars("Enable & disable"), "Enable &amp; disable");
-    assert_eq!(escape_special_chars("Wait<10"), "Wait &lt;10");
-    assert_eq!(escape_special_chars("Delay>5"), "Delay &gt;5");
-    assert_eq!(escape_special_chars("Flags & [Status] >100"), "Flags &amp; \\[Status\\] &gt; 1");
+    assert_eq!(escape_special_chars("Wait < 10"), "Wait &lt; 10");
+    assert_eq!(escape_special_chars("Delay > 5"), "Delay &gt; 5");
+    assert_eq!(
+        escape_special_chars("Flags & [Status] > 100"),
+        "Flags &amp; \\[Status\\] &gt; 100"
+    );
 }
+

--- a/src/util.rs
+++ b/src/util.rs
@@ -179,11 +179,24 @@ pub fn escape_brackets(s: &str) -> String {
 
 /// Escape basic html tags and brackets
 pub fn escape_special_chars(s: &str) -> Cow<'_, str> {
-    if s.contains('[') {
-        escape_brackets(s).into()
-    } else {
-        s.into()
+    if !s.contains('[') && !s.contains('&') && !s.contains('<') && !s.contains('>'){
+        return s.into();
     }
+    let mut escaped = s.to_string();
+    if escaped.contains('&') {
+        escaped = escaped.replace('&', "&amp;");
+    }
+    if escaped.contains('<') {
+        escaped = escaped.replace('<', "&lt;");
+    }
+    if escaped.contains('>') {
+        escaped = escaped.replace('>', "&gt;");
+    }
+    if escaped.contains('[') {
+        escaped = escape_brackets(&escaped);
+    }
+    escaped.into()
+
 }
 
 pub fn name_of<T: FullName>(maybe_array: &MaybeArray<T>, ignore_group: bool) -> String {
@@ -512,4 +525,12 @@ fn pascalcase() {
     assert_eq!(to_pascal_case("FOO_BAR_1"), "FooBar1");
     assert_eq!(to_pascal_case("FOO_BAR_1_2"), "FooBar1_2");
     assert_eq!(to_pascal_case("FOO_BAR_1_2_"), "FooBar1_2_");
+}
+
+fn test_escape_special_chars(){
+    assert_eq!(escape_special_chars("Array[0]"), "Array\\[0\\]");
+    assert_eq!(escape_special_chars("Enable & disable"), "Enable &amp; disable");
+    assert_eq!(escape_special_chars("Wait<10"), "Wait &lt;10");
+    assert_eq!(escape_special_chars("Delay>5"), "Delay &gt;5");
+    assert_eq!(escape_special_chars("Flags & [Status] >100"), "Flags &amp; \\[Status\\] &gt; 1");
 }

--- a/svd2rust-regress/src/tests.rs
+++ b/svd2rust-regress/src/tests.rs
@@ -27,6 +27,8 @@ pub enum Manufacturer {
     RaspberryPi,
     Renesas,
     Unknown,
+    GigaDevice,
+    WCH,
 }
 
 impl Manufacturer {
@@ -51,6 +53,8 @@ impl Manufacturer {
             Renesas,
             TexasInstruments,
             Espressif,
+            GigaDevice,
+            WCH,
         ]
     }
 }

--- a/svd2rust-regress/tests.yml
+++ b/svd2rust-regress/tests.yml
@@ -443,7 +443,11 @@
   mfgr: SiFive
   chip: fu540
   svd_url: https://raw.githubusercontent.com/riscv-rust/fu540-pac/master/fu540.svd
-
+- arch: riscv
+  mfgr: WCH
+  chip: ch32v30x
+  svd_url: https://raw.githubusercontent.com/ch32-rs/ch32v30x/main/ch32v30x.svd
+  
 # SiliconLabs
 - arch: cortex-m
   mfgr: SiliconLabs


### PR DESCRIPTION
This PR expands risc-v test area by adding the WCH CH32V30x chip to the regression suite. It introduced the WCH manufacturer to the test harness and also includes a new test case in tests.yml, which has been successfully verified locally through the regression tool.