### PR TITLE
use cortex-m-types crate for the InterruptNumber trait

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,11 +125,11 @@ jobs:
           cargo install svd2rust --path .
 
       # Install the MSRV toolchain
-      - uses: dtolnay/rust-toolchain@1.76.0
+      - uses: dtolnay/rust-toolchain@1.81.0
       - name: Run reression tool with MSRV
         # The MSRV only applies to the generated crate. The regress tool should still be run with
         # stable.
-        run: cargo +stable regress tests --toolchain 1.76.0 -m Nordic -- --strict --atomics
+        run: cargo +stable regress tests --toolchain 1.81.0 -m Nordic -- --strict --atomics
 
   ci-docs-clippy:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Use marker struct instead of address in `Periph` with `PeripheralSpec` trait
 - Add `--skip-peripherals-struct` flag to skip generating the `Peripherals`
   struct, its `take`/`steal` impl and the `DEVICE_PERIPHERALS` static
+- Generated `cortex-m` PACs now implement the `cortex_m_types::InterruptNumber` trait instead
+  of `cortex-m::interrupt::InterruptNumber` to avoid a hard dependency on `cortex-m` for PACs.
+  PACs should now use the `cortex-m-types` dependency instead of `cortex-m`.
 
 ## [v0.37.1] - 2025-10-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 - Generated `cortex-m` PACs now implement the `cortex_m_types::InterruptNumber` trait instead
   of `cortex-m::interrupt::InterruptNumber` to avoid a hard dependency on `cortex-m` for PACs.
   PACs should now use the `cortex-m-types` dependency instead of `cortex-m`.
+- Bump MSRV of generated code to 1.81
 
 ## [v0.37.1] - 2025-10-17
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ This project is developed and maintained by the [Tools team][team].
 
 ## Minimum Supported Rust Version (MSRV)
 
-The **generated code** is guaranteed to compile on stable Rust 1.76.0 and up.
+The **generated code** is guaranteed to compile on stable Rust 1.81.0 and up.
 
-If you encounter compilation errors on any stable version newer than 1.76.0, please open an issue.
+If you encounter compilation errors on any stable version newer than 1.81.0, please open an issue.
 
 # Testing Locally
 

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -120,7 +120,7 @@ pub fn render(
         (quote!(#[no_mangle]), quote!(extern))
     };
 
-    let n = util::unsuffixed(pos);
+    let num_of_interrupts = util::unsuffixed(pos);
     match target {
         Target::CortexM => {
             for name in &names {
@@ -154,7 +154,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
-                pub static __INTERRUPTS: [Vector; #n] = [
+                pub static __INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];
             });
@@ -193,7 +193,7 @@ pub fn render(
                 #nomangle
                 #[used]
                 pub static __INTERRUPTS:
-                    [Vector; #n] = [
+                    [Vector; #num_of_interrupts] = [
                         #elements
                     ];
             });
@@ -228,7 +228,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
-                pub static __EXTERNAL_INTERRUPTS: [Vector; #n] = [
+                pub static __EXTERNAL_INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];
             });
@@ -263,7 +263,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
-                pub static __INTERRUPTS: [Vector; #n] = [
+                pub static __INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];
             });
@@ -273,10 +273,10 @@ pub fn render(
     }
 
     let self_token = quote!(self);
-    let (enum_repr, nr_expr) = if variants.is_empty() {
-        (quote!(), quote!(match #self_token {}))
+    let enum_repr = if variants.is_empty() {
+        quote!()
     } else {
-        (quote!(#[repr(u16)]), quote!(#self_token as u16))
+        quote!(#[repr(u16)])
     };
 
     let defmt = config
@@ -309,13 +309,34 @@ pub fn render(
 
         match target {
             Target::CortexM => {
+                let num_value: usize = num_of_interrupts.base10_parse()?;
+                let max_interrupt_number = num_value.saturating_sub(1);
+
                 root.extend(quote! {
                     #interrupt_enum
 
-                    unsafe impl cortex_m::interrupt::InterruptNumber for Interrupt {
+                    unsafe impl cortex_m_types::InterruptNumber for Interrupt {
+                        const MAX_INTERRUPT_NUMBER: usize = #max_interrupt_number;
+
                         #[inline(always)]
-                        fn number(#self_token) -> u16 {
-                            #nr_expr
+                        fn number(#self_token) -> usize {
+                            #self_token as usize
+                        }
+
+                        /// Tries to convert a number to a valid interrupt.
+                        #[inline]
+                        fn from_number(value: usize) -> cortex_m_types::result::Result<Self> {
+                            if value > Self::MAX_INTERRUPT_NUMBER {
+                                return Err(cortex_m_types::result::Error::IndexOutOfBounds {
+                                    index: value,
+                                    min: 0,
+                                    max: Self::MAX_INTERRUPT_NUMBER,
+                                });
+                            }
+                            match value {
+                                #from_arms
+                                _ => Err(cortex_m_types::result::Error::InvalidVariant(value)),
+                            }
                         }
                     }
                 });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@
 //! ``` toml
 //! [dependencies]
 //! critical-section = { version = "1.0", optional = true }
-//! cortex-m = "0.7.6"
+//! cortex-m-types = "0.1"
 //! cortex-m-rt = { version = "0.6.13", optional = true }
 //! vcell = "0.1.2"
 //!

--- a/svd2rust-regress/src/svd_test.rs
+++ b/svd2rust-regress/src/svd_test.rs
@@ -18,7 +18,7 @@ const CRATES_ALL: &[&str] = &[
 const CRATES_MSP430: &[&str] = &["msp430 = \"0.4.0\"", "msp430-rt = \"0.4.0\""];
 const CRATES_ATOMICS: &[&str] =
     &["portable-atomic = { version = \"1\", default-features = false }"];
-const CRATES_CORTEX_M: &[&str] = &["cortex-m = \"0.7.6\"", "cortex-m-rt = \"0.7\""];
+const CRATES_CORTEX_M: &[&str] = &["cortex-m-types = \"0.1\"", "cortex-m-rt = \"0.7\""];
 const CRATES_RISCV: &[&str] = &["riscv = \"0.12.1\"", "riscv-rt = \"0.13.0\""];
 const CRATES_MIPS: &[&str] = &["mips-mcu = \"0.1.0\""];
 const PROFILE_ALL: &[&str] = &["[profile.dev]", "incremental = false"];


### PR DESCRIPTION
this is a  part of the effort to make updating `cortex-m` easier. PACs can now depend on `cortex-m-types` instead of `cortex-m`