### PR TITLE
fix: add #[used] for autogenerated __INTERRUTS static

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+- Add `#[used]` to the generated interrupt vector table statics so they are not
+  dropped by the linker with lto
 - Improve documentation for RISC-V settings file
 - Use marker struct instead of address in `Periph` with `PeripheralSpec` trait
 - Add `--skip-peripherals-struct` flag to skip generating the `Peripherals`

--- a/src/generate/interrupt.rs
+++ b/src/generate/interrupt.rs
@@ -154,6 +154,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
+                #[used]
                 pub static __INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];
@@ -228,6 +229,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
+                #[used]
                 pub static __EXTERNAL_INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];
@@ -263,6 +265,7 @@ pub fn render(
                 #[doc(hidden)]
                 #link_section_attr
                 #nomangle
+                #[used]
                 pub static __INTERRUPTS: [Vector; #num_of_interrupts] = [
                     #elements
                 ];


### PR DESCRIPTION
Closes #964
